### PR TITLE
Settings menu: type to fuzzy-filter

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -321,11 +321,14 @@ pub enum AppMode {
         selected: usize,
     },
     /// Settings menu (Ctrl+,): the full inventory of user-facing settings,
-    /// grouped and editable. `selected` indexes `settings::descriptors()`;
-    /// `editing` holds the in-progress numeric buffer when typing a value.
+    /// grouped and editable. `selected` indexes `settings::descriptors()`
+    /// (always a real, absolute index — never a position within the filtered
+    /// subset); `editing` holds the in-progress numeric buffer when typing a
+    /// value; `query` fuzzy-filters the list, matching the command palette.
     Settings {
         selected: usize,
         editing: Option<String>,
+        query: String,
     },
     /// A `--ff-only` pull failed on divergent branches: choose merge or rebase.
     /// The remote/branch to rerun with are held in `App.last_pull`.
@@ -1747,6 +1750,7 @@ impl App {
         self.mode = AppMode::Settings {
             selected: 0,
             editing: None,
+            query: String::new(),
         };
     }
 
@@ -1775,63 +1779,110 @@ impl App {
         Ok(())
     }
 
-    /// Settings menu: navigate, toggle/cycle, type numeric values, close. Edits
-    /// apply live and persist immediately.
+    /// Settings menu: navigate, toggle/cycle, type numeric values, fuzzy-filter
+    /// by label, close. Edits apply live and persist immediately.
+    ///
+    /// `selected` is always a real (absolute) index into `descriptors()`, even
+    /// while a filter is active — navigation and typing keep it synced to the
+    /// currently-visible subset (`crate::settings::filter_descriptors`), the
+    /// same "position lookup within a visible-index list" pattern the graph
+    /// panel's commit filter uses.
     fn handle_settings_action(&mut self, action: Action) -> Result<()> {
-        use crate::settings::{clamp_int, cycle_value, descriptors, SettingKind, SettingValue};
+        use crate::settings::{
+            clamp_int, cycle_value, descriptors, filter_descriptors, SettingKind, SettingValue,
+        };
 
         let ds = descriptors();
-        let n = ds.len();
-        let (selected, editing) = match &self.mode {
-            AppMode::Settings { selected, editing } => (*selected, editing.clone()),
+        let (selected, editing, query) = match &self.mode {
+            AppMode::Settings {
+                selected,
+                editing,
+                query,
+            } => (*selected, editing.clone(), query.clone()),
             _ => return Ok(()),
         };
+        let visible = filter_descriptors(&ds, &query);
 
         match action {
             Action::MoveUp => {
-                if let AppMode::Settings { selected, editing } = &mut self.mode {
-                    *selected = (*selected + n - 1) % n;
-                    *editing = None;
+                if !visible.is_empty() {
+                    let pos = visible.iter().position(|&i| i == selected).unwrap_or(0);
+                    let new_pos = (pos + visible.len() - 1) % visible.len();
+                    if let AppMode::Settings {
+                        selected, editing, ..
+                    } = &mut self.mode
+                    {
+                        *selected = visible[new_pos];
+                        *editing = None;
+                    }
                 }
             }
             Action::MoveDown => {
-                if let AppMode::Settings { selected, editing } = &mut self.mode {
-                    *selected = (*selected + 1) % n;
-                    *editing = None;
+                if !visible.is_empty() {
+                    let pos = visible.iter().position(|&i| i == selected).unwrap_or(0);
+                    let new_pos = (pos + 1) % visible.len();
+                    if let AppMode::Settings {
+                        selected, editing, ..
+                    } = &mut self.mode
+                    {
+                        *selected = visible[new_pos];
+                        *editing = None;
+                    }
                 }
             }
             Action::MenuSelect => {
-                let d = &ds[selected];
-                match (&editing, d.kind) {
-                    // Commit a typed numeric value.
-                    (Some(buf), SettingKind::Int { .. }) => {
-                        let parsed = buf.parse::<u64>().ok();
-                        if let AppMode::Settings { editing, .. } = &mut self.mode {
-                            *editing = None;
+                // Only act on a setting that's actually shown under the
+                // current filter (guards against a stale selection).
+                if visible.contains(&selected) {
+                    let d = &ds[selected];
+                    match (&editing, d.kind) {
+                        // Commit a typed numeric value.
+                        (Some(buf), SettingKind::Int { .. }) => {
+                            let parsed = buf.parse::<u64>().ok();
+                            if let AppMode::Settings { editing, .. } = &mut self.mode {
+                                *editing = None;
+                            }
+                            if let Some(parsed) = parsed {
+                                let value = SettingValue::Int(clamp_int(&d.kind, parsed));
+                                self.commit_setting(d, value)?;
+                            }
                         }
-                        if let Some(parsed) = parsed {
-                            let value = SettingValue::Int(clamp_int(&d.kind, parsed));
-                            self.commit_setting(d, value)?;
+                        // Otherwise cycle/toggle the current value.
+                        _ => {
+                            let next = cycle_value(&d.kind, d.get(self));
+                            self.commit_setting(d, next)?;
                         }
-                    }
-                    // Otherwise cycle/toggle the current value.
-                    _ => {
-                        let next = cycle_value(&d.kind, d.get(self));
-                        self.commit_setting(d, next)?;
                     }
                 }
             }
-            // Digit typing builds a numeric edit buffer for Int settings.
-            Action::InputChar(c) if c.is_ascii_digit() => {
-                if matches!(ds[selected].kind, SettingKind::Int { .. }) {
-                    if let AppMode::Settings { editing, .. } = &mut self.mode {
-                        let buf = editing.get_or_insert_with(String::new);
-                        // Cap length so absurd input can't overflow u64.
-                        if buf.len() < 7 {
-                            buf.push(c);
-                        }
+            // A digit starts (or continues) an inline numeric edit only when
+            // no filter is active yet and the selected setting takes a
+            // number — the pre-existing shortcut. Once a filter is active
+            // (or the setting isn't numeric), typing always wins: digits
+            // fall through to the catch-all arm below and filter like any
+            // other character.
+            Action::InputChar(c)
+                if c.is_ascii_digit()
+                    && (editing.is_some()
+                        || (query.is_empty()
+                            && matches!(ds[selected].kind, SettingKind::Int { .. }))) =>
+            {
+                if let AppMode::Settings { editing, .. } = &mut self.mode {
+                    let buf = editing.get_or_insert_with(String::new);
+                    // Cap length so absurd input can't overflow u64.
+                    if buf.len() < 7 {
+                        buf.push(c);
                     }
                 }
+            }
+            // Everything else (letters, and digits once filtering or off a
+            // numeric setting) types into the filter query. This also cancels
+            // an in-progress numeric edit — typing a non-digit mid-edit means
+            // the user's switched to searching, not finishing the number.
+            Action::InputChar(c) => {
+                let mut new_query = query;
+                new_query.push(c);
+                self.apply_settings_query(new_query);
             }
             Action::InputBackspace => {
                 if let AppMode::Settings {
@@ -1844,14 +1895,30 @@ impl App {
                             *editing = None;
                         }
                     }
+                } else if !query.is_empty() {
+                    let mut new_query = query;
+                    new_query.pop();
+                    self.apply_settings_query(new_query);
                 }
             }
+            Action::InputBackspaceWord if editing.is_none() && !query.is_empty() => {
+                let mut new_query = query;
+                crate::text_editor::pop_word(&mut new_query);
+                self.apply_settings_query(new_query);
+            }
+            Action::InputClearLine if editing.is_none() && !query.is_empty() => {
+                self.apply_settings_query(String::new());
+            }
             Action::Cancel => {
-                // Esc cancels an in-progress edit first, else closes the menu.
+                // Esc unwinds one layer at a time: cancel an in-progress
+                // numeric edit first, else clear an active filter, else
+                // close the menu.
                 if editing.is_some() {
                     if let AppMode::Settings { editing, .. } = &mut self.mode {
                         *editing = None;
                     }
+                } else if !query.is_empty() {
+                    self.apply_settings_query(String::new());
                 } else {
                     self.mode = AppMode::Normal;
                 }
@@ -1859,6 +1926,30 @@ impl App {
             _ => {}
         }
         Ok(())
+    }
+
+    /// Apply a new settings-menu filter query: if the current selection fell
+    /// out of the now-visible subset, jump to the first visible item (mirrors
+    /// `BranchFilter`'s "reset selection on filter change"). Also cancels any
+    /// in-progress numeric edit, since filtering and editing are exclusive.
+    fn apply_settings_query(&mut self, new_query: String) {
+        use crate::settings::{descriptors, filter_descriptors};
+        let ds = descriptors();
+        let visible = filter_descriptors(&ds, &new_query);
+        if let AppMode::Settings {
+            selected,
+            editing,
+            query,
+        } = &mut self.mode
+        {
+            *editing = None;
+            if !visible.contains(selected) {
+                if let Some(&first) = visible.first() {
+                    *selected = first;
+                }
+            }
+            *query = new_query;
+        }
     }
 
     /// Pull-divergence prompt: pick merge (0) or rebase (1), or cancel. The
@@ -1904,6 +1995,217 @@ impl App {
         // Close the error on any key
         if matches!(action, Action::Quit | Action::Cancel | Action::Confirm) {
             self.mode = AppMode::Normal;
+        }
+    }
+}
+
+#[cfg(test)]
+mod settings_menu_filter_tests {
+    use super::*;
+    use crate::test_support::git;
+
+    fn test_app() -> (tempfile::TempDir, App) {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dir = tmp.path();
+        git(dir, &["init", "-q", "-b", "main"]);
+        std::fs::write(dir.join("f.txt"), "base\n").unwrap();
+        git(dir, &["add", "."]);
+        git(dir, &["commit", "-q", "-m", "initial"]);
+        let repo = GitRepository::open(dir).expect("open repo");
+        let app = App::from_repo(repo).expect("build app");
+        (tmp, app)
+    }
+
+    fn type_str(app: &mut App, s: &str) {
+        for c in s.chars() {
+            app.handle_action(Action::InputChar(c)).expect("type char");
+        }
+    }
+
+    fn settings_query(app: &App) -> &str {
+        match &app.mode {
+            AppMode::Settings { query, .. } => query,
+            other => panic!("expected AppMode::Settings, got {other:?}"),
+        }
+    }
+
+    fn settings_selected(app: &App) -> usize {
+        match &app.mode {
+            AppMode::Settings { selected, .. } => *selected,
+            other => panic!("expected AppMode::Settings, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn typing_narrows_selection_to_the_fuzzy_matching_subset() {
+        let (_tmp, mut app) = test_app();
+        app.open_settings();
+        type_str(&mut app, "dim");
+
+        assert_eq!(settings_query(&app), "dim");
+        let ds = crate::settings::descriptors();
+        let visible = crate::settings::filter_descriptors(&ds, "dim");
+        assert!(!visible.is_empty(), "test fixture: 'dim' must match something");
+        assert!(
+            visible.contains(&settings_selected(&app)),
+            "selection must land inside the filtered subset"
+        );
+        assert_eq!(ds[settings_selected(&app)].label, "Dim merged branches");
+    }
+
+    #[test]
+    fn empty_query_leaves_every_descriptor_reachable() {
+        let (_tmp, mut app) = test_app();
+        app.open_settings();
+        let ds = crate::settings::descriptors();
+        assert_eq!(settings_query(&app), "");
+        // Walking MoveDown the full length must visit every descriptor
+        // exactly once before wrapping — i.e. nothing is pre-filtered.
+        let mut seen = std::collections::HashSet::new();
+        seen.insert(settings_selected(&app));
+        for _ in 1..ds.len() {
+            app.handle_action(Action::MoveDown).unwrap();
+            seen.insert(settings_selected(&app));
+        }
+        assert_eq!(seen.len(), ds.len());
+    }
+
+    #[test]
+    fn no_match_yields_an_empty_list_and_navigation_is_a_no_op() {
+        let (_tmp, mut app) = test_app();
+        app.open_settings();
+        type_str(&mut app, "zzzqqqxxx_no_such_setting");
+        let before = settings_selected(&app);
+        app.handle_action(Action::MoveDown).unwrap();
+        app.handle_action(Action::MoveUp).unwrap();
+        assert_eq!(settings_selected(&app), before, "no visible rows to move between");
+    }
+
+    #[test]
+    fn navigation_clamps_within_the_filtered_subset() {
+        let (_tmp, mut app) = test_app();
+        app.open_settings();
+        // "e" matches many settings; the point is just that every step must
+        // stay inside the filtered set — never park on a filtered-out row.
+        type_str(&mut app, "e");
+        let ds = crate::settings::descriptors();
+        let visible = crate::settings::filter_descriptors(&ds, "e");
+        assert!(visible.len() > 1, "test fixture needs >1 match to prove clamping");
+        for _ in 0..(visible.len() * 2 + 1) {
+            app.handle_action(Action::MoveDown).unwrap();
+            assert!(visible.contains(&settings_selected(&app)));
+        }
+        for _ in 0..(visible.len() * 2 + 1) {
+            app.handle_action(Action::MoveUp).unwrap();
+            assert!(visible.contains(&settings_selected(&app)));
+        }
+    }
+
+    #[test]
+    fn menu_select_toggles_the_currently_filtered_setting() {
+        let (_tmp, mut app) = test_app();
+        let before = app.merged.dim;
+        app.open_settings();
+        type_str(&mut app, "Dim merged"); // unique match: "Dim merged branches"
+        assert_eq!(
+            crate::settings::descriptors()[settings_selected(&app)].label,
+            "Dim merged branches"
+        );
+        app.handle_action(Action::MenuSelect).unwrap();
+        assert_eq!(app.merged.dim, !before, "MenuSelect must act on the filtered selection");
+    }
+
+    #[test]
+    fn esc_first_clears_the_query_then_closes_the_menu() {
+        let (_tmp, mut app) = test_app();
+        app.open_settings();
+        type_str(&mut app, "dim");
+        assert_eq!(settings_query(&app), "dim");
+
+        app.handle_action(Action::Cancel).unwrap();
+        assert_eq!(
+            settings_query(&app),
+            "",
+            "first Esc clears the query but stays open"
+        );
+        assert!(matches!(app.mode, AppMode::Settings { .. }));
+
+        app.handle_action(Action::Cancel).unwrap();
+        assert!(
+            matches!(app.mode, AppMode::Normal),
+            "second Esc (now with an empty query) closes the menu"
+        );
+    }
+
+    #[test]
+    fn esc_with_no_query_closes_immediately() {
+        let (_tmp, mut app) = test_app();
+        app.open_settings();
+        app.handle_action(Action::Cancel).unwrap();
+        assert!(matches!(app.mode, AppMode::Normal));
+    }
+
+    #[test]
+    fn backspace_pops_the_query_one_character_at_a_time() {
+        let (_tmp, mut app) = test_app();
+        app.open_settings();
+        type_str(&mut app, "dim");
+        app.handle_action(Action::InputBackspace).unwrap();
+        assert_eq!(settings_query(&app), "di");
+        app.handle_action(Action::InputBackspace).unwrap();
+        app.handle_action(Action::InputBackspace).unwrap();
+        assert_eq!(settings_query(&app), "");
+        // Backspacing an already-empty query is a no-op, not a close.
+        app.handle_action(Action::InputBackspace).unwrap();
+        assert_eq!(settings_query(&app), "");
+        assert!(matches!(app.mode, AppMode::Settings { .. }));
+    }
+
+    #[test]
+    fn digit_starts_a_numeric_edit_only_while_the_query_is_empty() {
+        let (_tmp, mut app) = test_app();
+        app.open_settings();
+        // Move onto an Int-kind setting ("Graph split ratio %").
+        let ds = crate::settings::descriptors();
+        let int_idx = ds
+            .iter()
+            .position(|d| matches!(d.kind, crate::settings::SettingKind::Int { .. }))
+            .expect("fixture needs an Int setting");
+        while settings_selected(&app) != int_idx {
+            app.handle_action(Action::MoveDown).unwrap();
+        }
+        // With an empty query, a digit starts the legacy numeric-edit buffer.
+        app.handle_action(Action::InputChar('4')).unwrap();
+        match &app.mode {
+            AppMode::Settings { editing, query, .. } => {
+                assert_eq!(editing.as_deref(), Some("4"));
+                assert_eq!(query, "");
+            }
+            other => panic!("expected Settings mode, got {other:?}"),
+        }
+        // A non-digit character mid-edit cancels the edit and starts filtering.
+        app.handle_action(Action::InputChar('x')).unwrap();
+        match &app.mode {
+            AppMode::Settings { editing, query, .. } => {
+                assert_eq!(*editing, None, "typing a letter must cancel the numeric edit");
+                assert_eq!(query, "x");
+            }
+            other => panic!("expected Settings mode, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn digits_filter_once_a_query_is_already_active() {
+        let (_tmp, mut app) = test_app();
+        app.open_settings();
+        type_str(&mut app, "e"); // start a non-empty text filter first
+        app.handle_action(Action::InputChar('5')).unwrap();
+        match &app.mode {
+            AppMode::Settings { editing, query, .. } => {
+                assert_eq!(*editing, None, "digit must not start a numeric edit mid-filter");
+                assert_eq!(query, "e5");
+            }
+            other => panic!("expected Settings mode, got {other:?}"),
         }
     }
 }

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -601,26 +601,29 @@ fn map_metadata_menu_mode(key: KeyEvent) -> Option<Action> {
     }
 }
 
-/// Settings menu: j/k (or arrows) move, Space/Enter toggles or cycles, digits
-/// type a numeric value (committed with Enter), Backspace edits it, Esc closes.
-/// 'q' is intentionally NOT a close key here — it's a digit-adjacent letter and
-/// numeric editing wants letters inert, so only Esc closes.
+/// Settings menu: arrows move, Space/Enter toggles or cycles, typing
+/// fuzzy-filters the list by label (mirrors the command palette), Backspace
+/// edits the filter (or an in-progress numeric buffer), Esc unwinds one layer
+/// at a time (cancel edit → clear filter → close).
+///
+/// 'j'/'k' are intentionally NOT nav aliases here (unlike other list modes)
+/// since they're ordinary filterable letters once typing is live — only the
+/// arrow keys move the selection. Space stays a toggle, not filter text
+/// (matching `BranchFilter`, which reserves Space for its own toggle too).
 fn map_settings_menu_mode(key: KeyEvent) -> Option<Action> {
+    if let Some(action) = map_text_editing_shortcut(key) {
+        return Some(action);
+    }
     match (key.modifiers, key.code) {
-        (KeyModifiers::NONE, KeyCode::Up) | (KeyModifiers::NONE, KeyCode::Char('k')) => {
-            Some(Action::MoveUp)
-        }
-        (KeyModifiers::NONE, KeyCode::Down) | (KeyModifiers::NONE, KeyCode::Char('j')) => {
-            Some(Action::MoveDown)
-        }
+        (KeyModifiers::NONE, KeyCode::Up) => Some(Action::MoveUp),
+        (KeyModifiers::NONE, KeyCode::Down) => Some(Action::MoveDown),
         (KeyModifiers::NONE, KeyCode::Char(' ')) | (KeyModifiers::NONE, KeyCode::Enter) => {
             Some(Action::MenuSelect)
         }
         (KeyModifiers::NONE, KeyCode::Esc) => Some(Action::Cancel),
         (KeyModifiers::NONE, KeyCode::Backspace) => Some(Action::InputBackspace),
-        // Digits feed the numeric edit buffer; the handler ignores them unless
-        // the selected setting is an integer.
-        (KeyModifiers::NONE, KeyCode::Char(c)) if c.is_ascii_digit() => Some(Action::InputChar(c)),
+        (KeyModifiers::NONE, KeyCode::Char(c)) => Some(Action::InputChar(c)),
+        (KeyModifiers::SHIFT, KeyCode::Char(c)) => Some(Action::InputChar(c)),
         _ => None,
     }
 }
@@ -1092,6 +1095,68 @@ mod tests {
     fn ctrl_comma_still_opens_settings() {
         let key = KeyEvent::new(KeyCode::Char(','), KeyModifiers::CONTROL);
         assert_eq!(map_normal(key), Some(Action::OpenSettings));
+    }
+
+    #[test]
+    fn settings_menu_letters_type_into_the_filter_not_nav_shortcuts() {
+        // 'j'/'k' used to be MoveDown/MoveUp aliases; once typing filters the
+        // list they must behave like every other letter.
+        let j = KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE);
+        let k = KeyEvent::new(KeyCode::Char('k'), KeyModifiers::NONE);
+        assert_eq!(map_settings_menu_mode(j), Some(Action::InputChar('j')));
+        assert_eq!(map_settings_menu_mode(k), Some(Action::InputChar('k')));
+        // An arbitrary letter also types.
+        let d = KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE);
+        assert_eq!(map_settings_menu_mode(d), Some(Action::InputChar('d')));
+        // Uppercase (Shift held) types too.
+        let shift_d = KeyEvent::new(KeyCode::Char('D'), KeyModifiers::SHIFT);
+        assert_eq!(map_settings_menu_mode(shift_d), Some(Action::InputChar('D')));
+    }
+
+    #[test]
+    fn settings_menu_arrows_still_navigate() {
+        let up = KeyEvent::new(KeyCode::Up, KeyModifiers::NONE);
+        let down = KeyEvent::new(KeyCode::Down, KeyModifiers::NONE);
+        assert_eq!(map_settings_menu_mode(up), Some(Action::MoveUp));
+        assert_eq!(map_settings_menu_mode(down), Some(Action::MoveDown));
+    }
+
+    #[test]
+    fn settings_menu_space_and_enter_still_select_not_type() {
+        let space = KeyEvent::new(KeyCode::Char(' '), KeyModifiers::NONE);
+        let enter = KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE);
+        assert_eq!(map_settings_menu_mode(space), Some(Action::MenuSelect));
+        assert_eq!(map_settings_menu_mode(enter), Some(Action::MenuSelect));
+    }
+
+    #[test]
+    fn settings_menu_digits_still_route_through_input_char() {
+        // The handler (not the keybinding layer) decides whether a digit
+        // starts a numeric edit or filters, based on live state.
+        let five = KeyEvent::new(KeyCode::Char('5'), KeyModifiers::NONE);
+        assert_eq!(map_settings_menu_mode(five), Some(Action::InputChar('5')));
+    }
+
+    #[test]
+    fn settings_menu_esc_backspace_map_unconditionally() {
+        // The three-way Esc priority (cancel edit / clear filter / close) and
+        // backspace's dual role (filter vs numeric buffer) are decided by the
+        // action handler, not the keybinding layer — both always map here.
+        let esc = KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE);
+        let bs = KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE);
+        assert_eq!(map_settings_menu_mode(esc), Some(Action::Cancel));
+        assert_eq!(map_settings_menu_mode(bs), Some(Action::InputBackspace));
+    }
+
+    #[test]
+    fn settings_menu_ctrl_w_and_ctrl_u_edit_shortcuts_still_work() {
+        let ctrl_w = KeyEvent::new(KeyCode::Backspace, KeyModifiers::CONTROL);
+        let ctrl_u = KeyEvent::new(KeyCode::Char('u'), KeyModifiers::CONTROL);
+        assert_eq!(
+            map_settings_menu_mode(ctrl_w),
+            Some(Action::InputBackspaceWord)
+        );
+        assert_eq!(map_settings_menu_mode(ctrl_u), Some(Action::InputClearLine));
     }
 
     #[test]

--- a/src/palette.rs
+++ b/src/palette.rs
@@ -14,6 +14,14 @@ use crate::action::Action;
 /// Maximum results rendered; the rest are summarised as "…N more".
 pub const PALETTE_CAP: usize = 15;
 
+/// Score `text` against `query` with the skim fuzzy algorithm; `None` if it
+/// doesn't match at all. The one matcher shared by every fuzzy-filtered list
+/// in the app (command palette, settings menu, ...) so there is exactly one
+/// notion of "fuzzy match" to reason about.
+pub(crate) fn fuzzy_score(text: &str, query: &str) -> Option<i64> {
+    SkimMatcherV2::default().fuzzy_match(text, query)
+}
+
 /// Which source a palette row came from — also the display tag and the
 /// equal-score tiebreak order (commands rank above branches above commits).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -186,14 +194,9 @@ pub fn rank(query: &str, candidates: Vec<Candidate>, cap: usize) -> PaletteResul
         return PaletteResults { items, more };
     }
 
-    let matcher = SkimMatcherV2::default();
     let mut scored: Vec<(i64, Candidate)> = candidates
         .into_iter()
-        .filter_map(|c| {
-            matcher
-                .fuzzy_match(&c.match_text, query)
-                .map(|score| (score, c))
-        })
+        .filter_map(|c| fuzzy_score(&c.match_text, query).map(|score| (score, c)))
         .collect();
 
     scored.sort_by(|(sa, a), (sb, b)| {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -250,6 +250,21 @@ pub fn clamp_int(kind: &SettingKind, n: u64) -> u64 {
     }
 }
 
+/// Indices into `ds` whose label fuzzy-matches `query`, in `ds`'s original
+/// (grouped) order — filtering narrows the menu, it doesn't re-rank it, so
+/// group structure survives. Uses the same matcher as the command palette
+/// ([`crate::palette::fuzzy_score`]). An empty (or whitespace-only) query
+/// matches everything, mirroring the palette's empty-query convention.
+pub fn filter_descriptors(ds: &[SettingDescriptor], query: &str) -> Vec<usize> {
+    if query.trim().is_empty() {
+        return (0..ds.len()).collect();
+    }
+    ds.iter()
+        .enumerate()
+        .filter_map(|(i, d)| crate::palette::fuzzy_score(d.label, query).map(|_| i))
+        .collect()
+}
+
 fn set_bool(v: SettingValue, target: &mut bool) {
     if let SettingValue::Bool(b) = v {
         *target = b;
@@ -724,5 +739,70 @@ mod tests {
         ] {
             assert_eq!(renderer_from_index(renderer_index(r)), r);
         }
+    }
+
+    // ── filter_descriptors ──────────────────────────────────────────
+
+    #[test]
+    fn empty_query_matches_every_descriptor_in_original_order() {
+        let ds = descriptors();
+        let visible = filter_descriptors(&ds, "");
+        assert_eq!(visible, (0..ds.len()).collect::<Vec<_>>());
+
+        // Whitespace-only is treated the same as empty (mirrors the palette).
+        let visible = filter_descriptors(&ds, "   ");
+        assert_eq!(visible, (0..ds.len()).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn query_narrows_to_fuzzy_matching_labels_only() {
+        let ds = descriptors();
+        let visible = filter_descriptors(&ds, "dim");
+        assert!(!visible.is_empty());
+        for &i in &visible {
+            assert!(
+                crate::palette::fuzzy_score(ds[i].label, "dim").is_some(),
+                "{} should fuzzy-match 'dim'",
+                ds[i].label
+            );
+        }
+        // "Dim merged branches" is the only label containing "dim".
+        assert!(visible.iter().any(|&i| ds[i].label == "Dim merged branches"));
+        // A setting with no relationship to "dim" must be excluded.
+        assert!(!visible.iter().any(|&i| ds[i].label == "Auto-fetch"));
+    }
+
+    #[test]
+    fn query_preserves_original_group_order_not_score_order() {
+        // Filtering narrows the list; it must not re-rank it — group headers
+        // in the widget rely on this staying in `descriptors()` order.
+        let ds = descriptors();
+        let visible = filter_descriptors(&ds, "e");
+        let mut sorted = visible.clone();
+        sorted.sort_unstable();
+        assert_eq!(visible, sorted, "filtered indices must stay in ascending/original order");
+    }
+
+    #[test]
+    fn nonsense_query_matches_nothing() {
+        let ds = descriptors();
+        let visible = filter_descriptors(&ds, "zzzqqqxxx_no_such_setting");
+        assert!(visible.is_empty());
+    }
+
+    #[test]
+    fn filter_matcher_is_the_same_one_the_command_palette_uses() {
+        // Regression guard against a second, drifting matcher implementation:
+        // filter_descriptors' matches must agree exactly with
+        // crate::palette::fuzzy_score for every descriptor label.
+        let ds = descriptors();
+        let query = "col";
+        let expected: Vec<usize> = ds
+            .iter()
+            .enumerate()
+            .filter(|(_, d)| crate::palette::fuzzy_score(d.label, query).is_some())
+            .map(|(i, _)| i)
+            .collect();
+        assert_eq!(filter_descriptors(&ds, query), expected);
     }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -624,17 +624,23 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
             frame.render_widget(PullDivergenceDialog::new(*selected, &theme), popup_area);
             rendered_popup = Some(popup_area);
         }
-        AppMode::Settings { selected, editing } => {
+        AppMode::Settings {
+            selected,
+            editing,
+            query,
+        } => {
             use self::settings_menu::SettingsMenuWidget;
             let values = app.settings_snapshot();
             // Rows + 4 group headers + footer + borders; cap to the frame.
+            // (A filter only ever shrinks the row count, so sizing off the
+            // full, unfiltered list is a safe upper bound.)
             let want = (crate::settings::descriptors().len()
                 + crate::settings::SettingGroup::ALL.len()
                 + 3) as u16;
             let height = want.min(area.height.saturating_sub(2)).max(6);
             let popup_area = centered_rect_fixed(52, height, area);
             frame.render_widget(
-                SettingsMenuWidget::new(&values, *selected, editing.as_deref(), &theme),
+                SettingsMenuWidget::new(&values, *selected, editing.as_deref(), query, &theme),
                 popup_area,
             );
             rendered_popup = Some(popup_area);

--- a/src/ui/settings_menu.rs
+++ b/src/ui/settings_menu.rs
@@ -1,11 +1,13 @@
 //! Settings menu popup widget (Ctrl+,).
 //!
 //! Stateless: it renders a snapshot of each setting's value (ordered to match
-//! `settings::descriptors()`) plus the current cursor and the (optional) numeric
-//! edit buffer. All settings logic lives in `crate::settings`;
-//! this widget only draws. Rows are grouped under dim section headers; the
-//! selected row is highlighted, and the right column shows each setting's value
-//! (or the live edit buffer when a numeric value is being typed).
+//! `settings::descriptors()`) plus the current cursor, the (optional) numeric
+//! edit buffer, and the (optional) fuzzy-filter query. All settings logic
+//! lives in `crate::settings`; this widget only draws. Rows are grouped under
+//! dim section headers — a header is shown only when at least one of its
+//! settings passes the current filter — and the selected row is highlighted,
+//! with the right column showing each setting's value (or the live edit
+//! buffer when a numeric value is being typed).
 
 use ratatui::{
     buffer::Buffer,
@@ -17,7 +19,7 @@ use ratatui::{
 use unicode_width::UnicodeWidthStr;
 
 use super::theme::Theme;
-use crate::settings::{descriptors, format_value, SettingGroup, SettingValue};
+use crate::settings::{descriptors, filter_descriptors, format_value, SettingGroup, SettingValue};
 
 /// One rendered line: a non-selectable section header, or a setting row keyed by
 /// its descriptor index.
@@ -33,6 +35,8 @@ pub struct SettingsMenuWidget<'a> {
     selected: usize,
     /// When the user is typing a numeric value, the in-progress buffer.
     editing: Option<&'a str>,
+    /// The live fuzzy-filter query; empty shows every setting.
+    query: &'a str,
     theme: &'a Theme,
 }
 
@@ -41,25 +45,29 @@ impl<'a> SettingsMenuWidget<'a> {
         values: &'a [SettingValue],
         selected: usize,
         editing: Option<&'a str>,
+        query: &'a str,
         theme: &'a Theme,
     ) -> Self {
         Self {
             values,
             selected,
             editing,
+            query,
             theme,
         }
     }
 
     /// Build the display rows (headers interleaved before each group's first
-    /// setting). Order follows `descriptors()`, which is grouped contiguously.
-    fn rows(count: usize, groups: &[SettingGroup]) -> Vec<Row> {
-        let mut rows = Vec::with_capacity(count + SettingGroup::ALL.len());
+    /// visible setting) from `visible` — indices into `descriptors()` that
+    /// pass the current filter, in `descriptors()`'s original (grouped) order.
+    fn rows(visible: &[usize], groups: &[SettingGroup]) -> Vec<Row> {
+        let mut rows = Vec::with_capacity(visible.len() + SettingGroup::ALL.len());
         let mut current: Option<SettingGroup> = None;
-        for (i, g) in groups.iter().enumerate().take(count) {
-            if current != Some(*g) {
-                rows.push(Row::Header(*g));
-                current = Some(*g);
+        for &i in visible {
+            let g = groups[i];
+            if current != Some(g) {
+                rows.push(Row::Header(g));
+                current = Some(g);
             }
             rows.push(Row::Item(i));
         }
@@ -71,7 +79,12 @@ impl<'a> Widget for SettingsMenuWidget<'a> {
     fn render(self, area: Rect, buf: &mut Buffer) {
         Clear.render(area, buf);
 
-        let block = self.theme.popup_block(" Settings ");
+        let title = if self.query.is_empty() {
+            " Settings ".to_string()
+        } else {
+            format!(" Settings [{}] ", self.query)
+        };
+        let block = self.theme.popup_block(title);
         let inner = block.inner(area);
         block.render(area, buf);
         if inner.width < 4 || inner.height < 2 {
@@ -81,7 +94,25 @@ impl<'a> Widget for SettingsMenuWidget<'a> {
 
         let ds = descriptors();
         let groups: Vec<SettingGroup> = ds.iter().map(|d| d.group).collect();
-        let rows = Self::rows(ds.len(), &groups);
+        let visible = filter_descriptors(&ds, self.query);
+        let rows = Self::rows(&visible, &groups);
+
+        let dim = Style::default()
+            .fg(self.theme.text_muted)
+            .add_modifier(Modifier::DIM);
+        let header_style = Style::default()
+            .fg(self.theme.help_key)
+            .add_modifier(Modifier::BOLD);
+
+        // Empty state: a dim placeholder instead of a blank body.
+        if rows.is_empty() {
+            buf.set_line(
+                inner.x,
+                inner.y,
+                &Line::from(Span::styled("no matching settings", self.theme.placeholder_style())),
+                inner.width,
+            );
+        }
 
         // Display-row index of the selected setting, for scroll bookkeeping.
         let selected_row = rows
@@ -96,13 +127,6 @@ impl<'a> Widget for SettingsMenuWidget<'a> {
         } else {
             0
         };
-
-        let dim = Style::default()
-            .fg(self.theme.text_muted)
-            .add_modifier(Modifier::DIM);
-        let header_style = Style::default()
-            .fg(self.theme.help_key)
-            .add_modifier(Modifier::BOLD);
 
         for (vis, row) in rows.iter().skip(scroll).take(list_height).enumerate() {
             let y = inner.y + vis as u16;
@@ -158,7 +182,7 @@ impl<'a> Widget for SettingsMenuWidget<'a> {
         // Footer.
         let footer_y = inner.y + inner.height.saturating_sub(1);
         let footer = Line::from(Span::styled(
-            "j/k move  Space toggle  0-9 set num  Esc close",
+            "↑↓ move  Space toggle  type filter  Esc close",
             dim,
         ));
         buf.set_line(inner.x, footer_y, &footer, inner.width);


### PR DESCRIPTION
## Summary

Typing in the Settings menu (Ctrl+,) now fuzzy-filters the list by label, mirroring the command palette's type-to-filter UX.

- **Matcher reuse**: extracted the palette's skim fuzzy matcher into a shared `crate::palette::fuzzy_score(text, query)`, used by both `palette::rank` and the new `settings::filter_descriptors(ds, query)` — one matcher, no duplication.
- **Display**: filtering narrows the list without re-ranking it — `filter_descriptors` preserves `descriptors()`'s original grouped order, so the widget's group-header structure survives; a header shows only for groups with a visible match. The query renders in the popup title (`Settings [dim]`), mirroring `BranchFilter`'s `[filter]` convention. Empty results show a dim "no matching settings" placeholder.
- **Navigation**: `selected` stays an absolute index into `descriptors()`; Up/Down step through the filtered subset via a position-lookup (same pattern as the graph panel's commit filter), and typing/backspace reselect the first visible item when the current selection drops out of the filtered set.
- **Esc**: unwinds one layer at a time — cancel an in-progress numeric edit first, else clear the filter, else close the menu. (These two states are mutually exclusive: starting to filter always cancels an in-progress edit.)
- **Keybinding conflicts resolved**: `j`/`k` were nav aliases for Up/Down — removed, since they're ordinary filterable letters once typing is live; only the arrow keys navigate now. Space/Enter still select (unchanged, matches `BranchFilter` reserving Space for its own toggle). Digits still start the legacy inline numeric-edit buffer, but only while no filter is active and the selected setting is numeric — once a filter is active, or the setting isn't numeric, digits fall through and filter like any other character ("typing wins").

## Test plan

- [x] `cargo test` — 1175 passed, 3 ignored
- [x] `cargo clippy --all-targets` — no issues
- [x] `debug-tui`: opened Ctrl+,, typed `dim`, dumped and confirmed the list narrowed to exactly "Dim merged branches" with the title showing `Settings [dim]`, toggled it with Space (On → Off confirmed on screen), first Esc cleared the filter back to the full list (mode stayed `settings`), second Esc closed the menu (mode → `normal`)
- New unit tests: `settings.rs` (`empty_query_matches_every_descriptor_in_original_order`, `query_narrows_to_fuzzy_matching_labels_only`, `query_preserves_original_group_order_not_score_order`, `nonsense_query_matches_nothing`, `filter_matcher_is_the_same_one_the_command_palette_uses`), `keybindings.rs` (`settings_menu_letters_type_into_the_filter_not_nav_shortcuts`, `settings_menu_arrows_still_navigate`, `settings_menu_space_and_enter_still_select_not_type`, `settings_menu_digits_still_route_through_input_char`, `settings_menu_esc_backspace_map_unconditionally`, `settings_menu_ctrl_w_and_ctrl_u_edit_shortcuts_still_work`), `app/mod.rs` (`settings_menu_filter_tests` module: typing/navigation clamping, empty/no-match query, `MenuSelect` on filtered selection, Esc two-stage, backspace, digit-vs-filter disambiguation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhXidvo7reDeAMi4M6B6JP