### PR TITLE
Dim merged branches dims whole lanes

### DIFF
--- a/src/app/init.rs
+++ b/src/app/init.rs
@@ -271,6 +271,7 @@ impl App {
                 pr_branches: std::collections::HashSet::new(),
                 pr_branch_fetch: crate::merged_branch_fetch::merged_branch_fetch(),
                 base_update: crate::signature_guarded::SignatureGuarded::default(),
+                lane_oids: std::collections::HashSet::new(),
             },
             metadata_columns: ui_state.metadata_columns,
             graph_width_cap: ui_state.graph_width_cap,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -850,6 +850,13 @@ pub struct MergedState {
     /// neither the base tip nor the open-PR head set has changed.
     pub base_update:
         crate::signature_guarded::SignatureGuarded<std::collections::HashSet<git2::Oid>>,
+    /// OIDs of commits exclusive to a merged branch's lane — the rows and graph
+    /// strokes the "dim merged branches" setting (`dim`) greys when hide is off
+    /// (issue #108). Recomputed on every graph rebuild from the loaded commits
+    /// (see `graph::merged_lane_oids`): exactly the commits that would vanish if
+    /// `hide` were toggled on. Empty when there are no merged branches or when
+    /// hide already removed them from the graph. Not persisted — derived state.
+    pub lane_oids: std::collections::HashSet<git2::Oid>,
 }
 
 /// Once-per-episode latches for periodically-retried refresh/poll errors. Each

--- a/src/app/refresh.rs
+++ b/src/app/refresh.rs
@@ -396,7 +396,47 @@ impl App {
         // Rebuild branch positions
         self.graph_nav
             .rebuild_branch_positions(&self.graph_layout, &self.repo.remotes());
+
+        // Recompute which commits are exclusive to a merged branch's lane, so
+        // the "dim merged branches" setting (#108) can grey their rows and graph
+        // strokes. Derived from the just-loaded commits + the current merged
+        // classification, so it stays in lock-step with every rebuild.
+        self.recompute_merged_lane_oids();
         Ok(())
+    }
+
+    /// Recompute `merged.lane_oids` — the commits exclusive to a merged branch's
+    /// lane — from the loaded commits and the current merged classification
+    /// (issue #108). Populated whenever a merged branch exists, independent of
+    /// the `dim`/`hide` toggles: the render path gates on `dim && !hide`, so
+    /// flipping the setting reflects instantly without a rebuild (like the merged
+    /// badge does). With `hide` on the merged commits aren't loaded, so the walk
+    /// naturally yields an empty set. Pure walk over `self.commits` via
+    /// `graph::merged_lane_oids` — no fresh revwalk.
+    fn recompute_merged_lane_oids(&mut self) {
+        if self.merged.branches.is_empty() {
+            self.merged.lane_oids.clear();
+            return;
+        }
+        let merged_tips: Vec<git2::Oid> = self
+            .branches
+            .iter()
+            .filter(|b| self.merged.branches.contains(&b.name))
+            .map(|b| b.tip_oid)
+            .collect();
+        // Live tips: every non-merged branch, plus HEAD (a detached or
+        // hidden-branch HEAD still anchors a first-parent line to protect).
+        let mut live_tips: Vec<git2::Oid> = self
+            .branches
+            .iter()
+            .filter(|b| !self.merged.branches.contains(&b.name))
+            .map(|b| b.tip_oid)
+            .collect();
+        if let Some(head) = self.repo.head_oid() {
+            live_tips.push(head);
+        }
+        self.merged.lane_oids =
+            crate::git::graph::merged_lane_oids(&self.commits, &merged_tips, &live_tips);
     }
 
     /// Phase 3 — re-point the cursor onto the equivalent row in the fresh graph.

--- a/src/git/graph.rs
+++ b/src/git/graph.rs
@@ -1446,6 +1446,85 @@ pub fn cell_is_traced(oids: CellOids, lit: &HashMap<CellEdge, Oid>) -> bool {
     edge_is_traced(oids.0, lit) || edge_is_traced(oids.1, lit)
 }
 
+/// The set of commit OIDs that would VANISH if "hide merged branches" were
+/// toggled on — every commit exclusive to a merged branch's lane. This is the
+/// selection the "dim merged branches" setting (issue #108) greys: both the
+/// commit rows and the graph strokes touching them.
+///
+/// Mirrors hide-merged's first-parent semantics (issue #91): a commit vanishes
+/// under hide-merged iff it is reachable from some merged branch tip yet lies on
+/// NO live (non-merged) ref's first-parent chain. So the returned set is
+///
+/// ```text
+///   reachable(merged_tips)  \  first_parent_chains(live_tips)
+/// ```
+///
+/// computed purely by walking the already-loaded `commits`' parent edges — no
+/// fresh revwalk. Off-graph parents end a walk (only loaded commits can be
+/// dimmed, matching what the renderer draws).
+///
+/// - `merged_tips`: tip OIDs of the merged branches (resolve names via the
+///   branch list).
+/// - `live_tips`: tip OIDs of every non-merged ref plus HEAD; their first-parent
+///   chains are protected from dimming, so shared trunk history a merged branch
+///   also reaches (down to and past its fork point) stays lit.
+pub fn merged_lane_oids(
+    commits: &[CommitInfo],
+    merged_tips: &[Oid],
+    live_tips: &[Oid],
+) -> HashSet<Oid> {
+    // oid -> its parent OIDs, for loaded commits only.
+    let parents: HashMap<Oid, &[Oid]> = commits
+        .iter()
+        .map(|c| (c.oid, c.parent_oids.as_slice()))
+        .collect();
+
+    // Protected: each live tip's first-parent chain, walked while loaded. A
+    // merged branch's shared trunk history lands here, so only its exclusive
+    // commits survive the difference below.
+    let mut live: HashSet<Oid> = HashSet::new();
+    for &tip in live_tips {
+        let mut cur = tip;
+        while parents.contains_key(&cur) && live.insert(cur) {
+            match parents[&cur].first().copied() {
+                Some(p) => cur = p,
+                None => break,
+            }
+        }
+    }
+
+    // Reachable from a merged tip via ANY parent edge (a merge's second parent
+    // included), restricted to loaded commits and stopping at any protected
+    // (live) commit — the walk into shared trunk history halts at the fork
+    // point, which is on the trunk's first-parent chain. What remains is
+    // exclusive to the merged lanes.
+    let mut merged: HashSet<Oid> = HashSet::new();
+    let mut stack: Vec<Oid> = merged_tips.to_vec();
+    while let Some(oid) = stack.pop() {
+        let Some(ps) = parents.get(&oid) else { continue };
+        if live.contains(&oid) || !merged.insert(oid) {
+            continue;
+        }
+        stack.extend(ps.iter().copied());
+    }
+    merged
+}
+
+/// Whether a single `(child, parent)` edge touches a dimmed (merged-lane)
+/// commit: either endpoint is in `merged`. An edge to/from a vanishing commit
+/// is exactly a stroke hide-merged would remove, so this is what the merged-lane
+/// dim (issue #108) fades. `None` (no edge) never touches.
+pub fn edge_touches_merged(edge: Option<CellEdge>, merged: &HashSet<Oid>) -> bool {
+    edge.is_some_and(|(child, parent)| merged.contains(&child) || merged.contains(&parent))
+}
+
+/// Whether a cell (by its `(primary, secondary)` edges) touches a merged-lane
+/// commit. Either edge counts — the Unicode text path dims the whole glyph;
+/// the pixel path fades each edge independently (see `apply_merged_lane_dim`).
+pub fn cell_touches_merged(oids: CellOids, merged: &HashSet<Oid>) -> bool {
+    edge_touches_merged(oids.0, merged) || edge_touches_merged(oids.1, merged)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2151,5 +2230,90 @@ mod tests {
                 }
             }
         }
+    }
+
+    // ── merged_lane_oids: which commits the dim-merged setting greys (#108) ──
+
+    /// Trunk A—B—C (A newest, C the loaded base whose parent Z is off-graph),
+    /// with three branches off C:
+    ///
+    /// - F1—F2: merged into A via a merge commit (A's 2nd parent is F1);
+    /// - S1: a squash-merged branch (its local ref survives but it is NOT an
+    ///   ancestor of the trunk);
+    /// - G1: an ordinary UNMERGED branch.
+    ///
+    /// Returns the commit list and the OIDs `[A, B, C, F1, F2, S1, G1, Z]`.
+    fn merged_lane_fixture() -> (Vec<CommitInfo>, [Oid; 8]) {
+        let (a, b, c, f1, f2, s1, g1, z) = (
+            oid(1),
+            oid(2),
+            oid(3),
+            oid(4),
+            oid(5),
+            oid(6),
+            oid(7),
+            oid(9),
+        );
+        let commits = vec![
+            ci(a, vec![b, f1]), // trunk merge: first parent B, 2nd parent F1
+            ci(b, vec![c]),
+            ci(f1, vec![f2]),
+            ci(f2, vec![c]),
+            ci(s1, vec![c]),
+            ci(g1, vec![c]),
+            ci(c, vec![z]), // trunk base; Z is off-graph (not loaded)
+        ];
+        (commits, [a, b, c, f1, f2, s1, g1, z])
+    }
+
+    #[test]
+    fn merged_lane_selects_only_merged_exclusive_commits() {
+        let (commits, [a, b, c, f1, f2, s1, g1, _z]) = merged_lane_fixture();
+        // F is merged via a merge commit; S is squash-merged (both have live
+        // refs). Trunk A and the unmerged branch G are the live lines.
+        let merged = merged_lane_oids(&commits, &[f1, s1], &[a, g1]);
+
+        // The merged branches' exclusive commits dim.
+        assert!(merged.contains(&f1), "merge-commit branch tip dims");
+        assert!(merged.contains(&f2), "merge-commit branch interior dims");
+        assert!(merged.contains(&s1), "squash-merged branch commit dims");
+        // Trunk first-parent commits never dim — even C, which the merged
+        // branches also reach (their walk stops at the shared fork point).
+        assert!(!merged.contains(&a), "trunk tip stays lit");
+        assert!(!merged.contains(&b), "trunk interior stays lit");
+        assert!(!merged.contains(&c), "shared fork-point commit stays lit");
+        // An unmerged branch is not in the merged-tip walk at all.
+        assert!(!merged.contains(&g1), "unmerged branch stays lit");
+    }
+
+    #[test]
+    fn merged_lane_spares_a_fast_forwarded_branch_on_the_trunk_line() {
+        // A branch whose commits sit on the trunk's own first-parent chain (a
+        // fast-forward merge left nothing exclusive) must NOT dim: hide-merged
+        // would keep those commits, so the dim mirror keeps them too.
+        let (commits, [a, b, _c, _f1, _f2, _s1, _g1, _z]) = merged_lane_fixture();
+        // Pretend B's branch is "merged" but the trunk tip A is still live and
+        // reaches B via its first parent.
+        let merged = merged_lane_oids(&commits, &[b], &[a]);
+        assert!(merged.is_empty(), "no commit exclusive to a ff-merged branch");
+    }
+
+    #[test]
+    fn merged_lane_is_empty_without_merged_tips() {
+        let (commits, [a, _b, _c, _f1, _f2, _s1, g1, _z]) = merged_lane_fixture();
+        assert!(merged_lane_oids(&commits, &[], &[a, g1]).is_empty());
+    }
+
+    #[test]
+    fn edge_and_cell_touch_merged_on_either_endpoint() {
+        let merged: HashSet<Oid> = [oid(4)].into_iter().collect();
+        // Either endpoint in the set makes the edge touch.
+        assert!(edge_touches_merged(Some((oid(4), oid(3))), &merged));
+        assert!(edge_touches_merged(Some((oid(1), oid(4))), &merged));
+        assert!(!edge_touches_merged(Some((oid(1), oid(3))), &merged));
+        assert!(!edge_touches_merged(None, &merged));
+        // A cell touches when either of its two edges does.
+        assert!(cell_touches_merged((None, Some((oid(4), oid(3)))), &merged));
+        assert!(!cell_touches_merged((Some((oid(1), oid(2))), None), &merged));
     }
 }

--- a/src/ui/graph_view.rs
+++ b/src/ui/graph_view.rs
@@ -513,7 +513,12 @@ pub fn dim_pixel_specs_window(
             app.merged.base_update.value(),
         );
     }
-    dim_specs_window_core(base, &row_oids, &force_dim, lit, lane_rgb, win_start, win_end)
+    // Merged-lane dim (#108), gated the same way the unicode path is: dim on and
+    // hide off. `None` = feature off, so the core skips the merged-lane pass.
+    let merged_oids = (app.merged.dim && !app.merged.hide).then_some(&app.merged.lane_oids);
+    dim_specs_window_core(
+        base, &row_oids, &force_dim, lit, lane_rgb, merged_oids, win_start, win_end,
+    )
 }
 
 /// Per-row edge identities for dimming: parallel to a row's pixel `cells` and
@@ -545,12 +550,14 @@ impl RowOids<'_> {
 /// dimming that row over the full range — dimming is per-row (`apply_trace_dim`
 /// reads only that row's cells and oids), so restricting which rows are built
 /// never changes a built row's content.
+#[allow(clippy::too_many_arguments)] // cohesive base specs + three dim sources + window bounds
 fn dim_specs_window_core(
     base: &[crate::ui::graph_pixels::RowSpec],
     row_oids: &[RowOids],
     force_dim: &[bool],
     lit: &std::collections::HashMap<crate::git::graph::CellEdge, git2::Oid>,
     lane_rgb: &std::collections::HashMap<git2::Oid, [u8; 3]>,
+    merged_oids: Option<&HashSet<git2::Oid>>,
     win_start: usize,
     win_end: usize,
 ) -> Vec<crate::ui::graph_pixels::RowSpec> {
@@ -569,9 +576,23 @@ fn dim_specs_window_core(
         } else if let Some(o) = row_oids.get(i) {
             // `spec.cells`/`spec.underlay` are (truncated) 1:1 with the node's
             // cells/underlay, so their OIDs align by index; dimming only reads
-            // the cells that survived truncation.
-            apply_trace_dim(&mut spec.cells, o.cells, lit, lane_rgb);
-            apply_trace_dim(&mut spec.underlay, o.underlay, lit, lane_rgb);
+            // the cells that survived truncation. Only run the trace pass when
+            // tracing is actually active (`lit` non-empty): with tracing off,
+            // `apply_trace_dim` would dim EVERY cell (nothing is lit), so the
+            // base specs must stay bright and let force-dim / merged-lane below
+            // be the only per-frame dim sources — matching this function's
+            // documented "no cell is dimmed by tracing when off" contract.
+            if !lit.is_empty() {
+                apply_trace_dim(&mut spec.cells, o.cells, lit, lane_rgb);
+                apply_trace_dim(&mut spec.underlay, o.underlay, lit, lane_rgb);
+            }
+        }
+        // Merged-lane dim (#108): grey the strokes touching a commit exclusive
+        // to a merged branch's lane — exactly the strokes hide-merged removes.
+        // Only ever SETS dim, so it composes on top of force-dim / trace above.
+        if let (Some(m), Some(o)) = (merged_oids, row_oids.get(i)) {
+            apply_merged_lane_dim(&mut spec.cells, o.cells, m);
+            apply_merged_lane_dim(&mut spec.underlay, o.underlay, m);
         }
         spec
     };
@@ -698,6 +719,42 @@ fn apply_trace_dim(
     }
 }
 
+/// Set `dim` on every pixel cell whose edge touches a merged-lane commit (issue
+/// #108) — exactly the strokes hide-merged would remove. Mirrors
+/// `apply_trace_dim`'s per-edge mapping (a `HorizontalPipe` fades each stroke
+/// from its own edge, a commit dot from either edge, every other shape from its
+/// primary edge) but ONLY dims: it never clears a `dim` flag and never recolors,
+/// so it composes on top of whatever trace/force-dim already decided.
+fn apply_merged_lane_dim(
+    cells: &mut [crate::ui::graph_pixels::PixelCell],
+    oids: &[crate::git::graph::CellOids],
+    merged: &HashSet<git2::Oid>,
+) {
+    use crate::git::graph::edge_touches_merged;
+    use crate::ui::graph_pixels::CellShape;
+    for (i, pc) in cells.iter_mut().enumerate() {
+        let (primary, secondary) = oids.get(i).copied().unwrap_or((None, None));
+        if pc.shape == CellShape::HorizontalPipe {
+            // Primary = the horizontal stroke (drawn in `secondary`); secondary =
+            // the vertical lane crossed underneath (drawn in `color`).
+            if edge_touches_merged(primary, merged) {
+                pc.dim_secondary = true;
+            }
+            if edge_touches_merged(secondary, merged) {
+                pc.dim = true;
+            }
+        } else if matches!(pc.shape, CellShape::Commit { .. }) {
+            if edge_touches_merged(primary, merged) || edge_touches_merged(secondary, merged) {
+                pc.dim = true;
+                pc.dim_secondary = true;
+            }
+        } else if edge_touches_merged(primary, merged) {
+            pc.dim = true;
+            pc.dim_secondary = true;
+        }
+    }
+}
+
 /// The half-open range of list rows worth building fully, given `n` total rows,
 /// the current scroll `offset`, the drawable `viewport` height, and the selected
 /// row's filtered position (if any).
@@ -746,6 +803,13 @@ impl<'a> GraphViewWidget<'a> {
         let pr_ctx = PrContext::new(open_prs);
         let merged_branches = &app.merged.branches;
         let merged_dim = app.merged.dim;
+        // Merged-lane dimming (#108): grey the rows AND graph strokes exclusive
+        // to a merged branch's lane. Gated on the dim setting with hide off
+        // (hide already removes them from the graph). `lane_oids` stays populated
+        // across the toggle, so gating here reflects a settings flip instantly
+        // without a rebuild — `None` = feature off, no row/cell is dimmed by it.
+        let merged_lane_oids = (app.merged.dim && !app.merged.hide)
+            .then_some(&app.merged.lane_oids);
         // OIDs of base-update ("back-merge") commits (#55); a per-row O(1)
         // membership test, so the check stays inside the windowed render path.
         let base_update_merges = app.merged.base_update.value();
@@ -772,6 +836,7 @@ impl<'a> GraphViewWidget<'a> {
             pr_ctx: &pr_ctx,
             merged_branches,
             merged_dim,
+            merged_lane_oids,
             base_update_merges,
             metadata_columns,
             graph_width,
@@ -1393,6 +1458,12 @@ struct RowRenderCtx<'a> {
     /// `merged_branches` classified the branch (ancestry, fast-forward, or
     /// squash all live in the same set).
     merged_dim: bool,
+    /// Commits exclusive to a merged branch's lane (issue #108), or `None` when
+    /// merged-lane dimming is off (`dim` off or `hide` on). When `Some`, a row
+    /// whose commit is in the set greys its text like a muted merge, and its
+    /// graph strokes (any cell edge touching one of these commits) dim — the
+    /// same strokes hide-merged would remove.
+    merged_lane_oids: Option<&'a HashSet<git2::Oid>>,
     base_update_merges: &'a HashSet<git2::Oid>,
     metadata_columns: MetadataColumns,
     /// Graph column width cap (glyph budget), same for every row this frame.
@@ -1429,6 +1500,15 @@ fn render_graph_line<'a>(
         ctx.base_update_merges,
     );
 
+    // Merged-lane row (#108): a commit exclusive to a merged branch's lane greys
+    // its message + metadata (like a muted merge) and dims its graph strokes.
+    // `ctx.merged_lane_oids` is `None` when the feature is off, so this is a
+    // cheap constant `false` in the common case.
+    let is_merged_lane = node
+        .commit
+        .as_ref()
+        .is_some_and(|c| ctx.merged_lane_oids.is_some_and(|s| s.contains(&c.oid)));
+
     // Graph start marker (to distinguish from borders). GRAPH_LEADING_COLUMNS
     // is the shared contract with the pixel overlay's x-offset.
     spans.push(Span::raw(" ".repeat(GRAPH_LEADING_COLUMNS as usize)));
@@ -1452,6 +1532,7 @@ fn render_graph_line<'a>(
         // Graph glyphs render bold; with tracing, non-lineage cells are dimmed.
         // A base-update back-merge (#55) force-dims its whole connector so the
         // noisy line recedes; ordinary merge muting stays in the message text.
+        // Merged-lane strokes (#108) dim per-cell, composing with the two above.
         left_width = render_cells_unicode(
             &mut spans,
             node,
@@ -1460,6 +1541,7 @@ fn render_graph_line<'a>(
             ctx.graph_width,
             ctx.trace,
             is_base_update,
+            ctx.merged_lane_oids,
         );
     }
 
@@ -1480,12 +1562,13 @@ fn render_graph_line<'a>(
         left_width += AVATAR_RESERVED_CELLS as usize;
     }
 
-    render_graph_line_tail(spans, left_width, node, ctx, flags, is_base_update)
+    render_graph_line_tail(spans, left_width, node, ctx, flags, is_base_update, is_merged_lane)
 }
 
 /// Render the Unicode box-drawing glyphs for a row's cells into `spans`, capped
 /// at `cap` graph columns, returning the updated `left_width`. When the row
 /// overflows the cap, the last column becomes a dim `…`.
+#[allow(clippy::too_many_arguments)] // cohesive per-row render + dim-source inputs
 fn render_cells_unicode(
     spans: &mut Vec<Span<'_>>,
     node: &GraphNode,
@@ -1494,20 +1577,23 @@ fn render_cells_unicode(
     cap: usize,
     trace: Option<&std::collections::HashMap<crate::git::graph::CellEdge, git2::Oid>>,
     force_dim: bool,
+    merged_oids: Option<&HashSet<git2::Oid>>,
 ) -> usize {
     // `budget` graph columns are available for glyphs; when truncating, one more
     // column holds the `…`.
     let (budget, ellipsis) = graph_truncation(node.cells.len(), cap);
 
-    // Whether the cell at `idx` should be dimmed: `force_dim` (a base-update
-    // back-merge row, #55) dims the entire connector; otherwise a cell dims when
-    // tracing is active and it is not lit by the selected commit's trace.
+    // Whether the cell at `idx` should be dimmed. Three independent sources
+    // compose (any one dims), mirroring the pixel path:
+    //   - `force_dim` (a base-update back-merge row, #55) dims the whole connector;
+    //   - a merged-lane stroke (#108): the cell's edge touches a commit exclusive
+    //     to a merged branch's lane — exactly a stroke hide-merged would remove;
+    //   - trace dim: tracing is active and the cell is not lit by the selection.
     let is_dim = |idx: usize| -> bool {
+        let oids = node.cell_oids.get(idx).copied().unwrap_or((None, None));
         force_dim
-            || trace.is_some_and(|lit| {
-                let oids = node.cell_oids.get(idx).copied().unwrap_or((None, None));
-                !crate::git::graph::cell_is_traced(oids, lit)
-            })
+            || merged_oids.is_some_and(|m| crate::git::graph::cell_touches_merged(oids, m))
+            || trace.is_some_and(|lit| !crate::git::graph::cell_is_traced(oids, lit))
     };
 
     // Render cells.
@@ -1617,6 +1703,7 @@ fn render_graph_line_tail<'a>(
     ctx: &RowRenderCtx<'_>,
     flags: RowFlags,
     is_base_update: bool,
+    is_merged_lane: bool,
 ) -> (Line<'a>, Vec<ChipHit>) {
     let mut chips: Vec<ChipHit> = Vec::new();
     // Separator between graph and commit info
@@ -1693,7 +1780,10 @@ fn render_graph_line_tail<'a>(
     // whole row, not just the message — DIM alone is too subtle (terminal
     // support is inconsistent), so the hash/author/date columns get the same
     // explicit `text_muted` foreground the message uses.
-    let row_is_muted = is_base_update || is_pr_merge || muted_merge || collapse_merge;
+    // A merged-lane commit (#108) reads muted too — its message, hash, author,
+    // and date all grey, matching the other muted categories (#92).
+    let row_is_muted =
+        is_base_update || is_pr_merge || muted_merge || collapse_merge || is_merged_lane;
     let hash_style = if row_is_muted {
         Style::default().fg(ctx.theme.text_muted)
     } else {
@@ -1728,7 +1818,9 @@ fn render_graph_line_tail<'a>(
             .add_modifier(Modifier::DIM)
     } else if is_pr_merge {
         Style::default().fg(ctx.theme.text_muted)
-    } else if muted_merge || collapse_merge {
+    } else if muted_merge || collapse_merge || is_merged_lane {
+        // Merged-lane commits (#108) share the ordinary muted-merge treatment:
+        // an explicit muted foreground plus DIM.
         Style::default()
             .fg(ctx.theme.text_muted)
             .add_modifier(Modifier::DIM)
@@ -3112,7 +3204,7 @@ mod tests {
     fn render_cells(node: &GraphNode, cap: usize) -> String {
         let theme = Theme::dark();
         let mut spans: Vec<Span> = Vec::new();
-        let lw = render_cells_unicode(&mut spans, node, &theme, 0, cap, None, false);
+        let lw = render_cells_unicode(&mut spans, node, &theme, 0, cap, None, false, None);
         let text: String = spans.iter().map(|s| s.content.as_ref()).collect();
         // left_width is columns emitted (started at 0); it must equal the text's
         // display width.
@@ -3250,6 +3342,7 @@ mod tests {
             pr_ctx: &pr_ctx,
             merged_branches: &HashSet::new(),
             merged_dim: true,
+            merged_lane_oids: None,
             base_update_merges,
             metadata_columns: cols,
             graph_width: 4,
@@ -3298,6 +3391,7 @@ mod tests {
             pr_ctx: &pr_ctx,
             merged_branches,
             merged_dim,
+            merged_lane_oids: None,
             base_update_merges: &HashSet::new(),
             metadata_columns: cols,
             graph_width: 4,
@@ -3460,6 +3554,129 @@ mod tests {
                 "unmerged branch never shows the merged badge (dim setting = {dim})"
             );
         }
+    }
+
+    // ── merged-lane dimming: whole rows grey (#108) ──────────────────────
+
+    /// Render one full graph row with a set of merged-LANE commit OIDs (#108)
+    /// and every metadata column on, so tests can assert the message and the
+    /// hash/author/date columns all grey. `lane_oids = None` renders the
+    /// feature off (the settings toggle held off / hide on).
+    fn render_row_with_merged_lane(
+        node: &GraphNode,
+        lane_oids: Option<&HashSet<git2::Oid>>,
+    ) -> Line<'static> {
+        let cols = MetadataColumns {
+            author: true,
+            hash: true,
+            date: true,
+            mute_merges: false,
+            mute_base_merges: false,
+            collapse_merges: false,
+            avatars: false,
+            pr_subjects: true,
+        };
+        let theme = Theme::dark();
+        let open_prs = HashMap::new();
+        let pr_ctx = PrContext::new(&open_prs);
+        let ctx = RowRenderCtx {
+            theme: &theme,
+            now: Local::now(),
+            pixel_mode: false,
+            remotes: &[],
+            open_prs: &open_prs,
+            pr_ctx: &pr_ctx,
+            merged_branches: &HashSet::new(),
+            merged_dim: false,
+            merged_lane_oids: lane_oids,
+            base_update_merges: &HashSet::new(),
+            metadata_columns: cols,
+            graph_width: 4,
+            total_width: 200,
+            selected_branch_name: None,
+            trace: None,
+        };
+        let (line, _chips) = render_graph_line(
+            node,
+            &ctx,
+            RowFlags {
+                is_selected: false,
+                is_marked: false,
+            },
+        );
+        line
+    }
+
+    #[test]
+    fn merged_lane_row_greys_message_and_metadata() {
+        // A commit exclusive to a merged branch's lane reads grey across the
+        // whole row — message DIM+greyed, and the metadata columns greyed (#92).
+        let theme = Theme::dark();
+        let node = commit_node(7, "landed feature work", &[]);
+        let lane: HashSet<git2::Oid> = [oid(7)].into_iter().collect();
+
+        let line = render_row_with_merged_lane(&node, Some(&lane));
+
+        let msg = find_style(&line, "landed feature work").expect("message span");
+        assert_eq!(
+            msg.fg,
+            Some(theme.text_muted),
+            "merged-lane message greyed: {msg:?}"
+        );
+        assert!(
+            msg.add_modifier.contains(Modifier::DIM),
+            "merged-lane message DIM: {msg:?}"
+        );
+        // author_name is "a", padded to 8; author_color != text_muted in dark.
+        let author = find_style(&line, &format!("{:<8}", "a")).expect("author span");
+        assert_eq!(
+            author.fg,
+            Some(theme.text_muted),
+            "merged-lane author column greyed: {author:?}"
+        );
+    }
+
+    #[test]
+    fn merged_lane_row_renders_normally_when_feature_off() {
+        // `None` = dim setting off (or hide on): the same row renders exactly
+        // like an ordinary commit — no grey, no DIM.
+        let theme = Theme::dark();
+        let node = commit_node(7, "landed feature work", &[]);
+
+        let line = render_row_with_merged_lane(&node, None);
+
+        let msg = find_style(&line, "landed feature work").expect("message span");
+        assert_eq!(msg.fg, None, "feature off: message not greyed: {msg:?}");
+        assert!(
+            !msg.add_modifier.contains(Modifier::DIM),
+            "feature off: message not DIM: {msg:?}"
+        );
+        let author = find_style(&line, &format!("{:<8}", "a")).expect("author span");
+        assert_eq!(
+            author.fg,
+            Some(theme.author_color),
+            "feature off: author column keeps its own color: {author:?}"
+        );
+    }
+
+    #[test]
+    fn commit_outside_the_merged_lane_stays_bright_when_feature_on() {
+        // Only commits IN the lane set dim — a trunk commit rendered while the
+        // feature is on keeps full-strength styling.
+        let theme = Theme::dark();
+        let trunk = commit_node(3, "trunk work", &[]);
+        let lane: HashSet<git2::Oid> = [oid(7)].into_iter().collect(); // trunk is oid(3)
+
+        let line = render_row_with_merged_lane(&trunk, Some(&lane));
+
+        let msg = find_style(&line, "trunk work").expect("message span");
+        assert_eq!(msg.fg, None, "non-lane commit not greyed: {msg:?}");
+        let author = find_style(&line, &format!("{:<8}", "a")).expect("author span");
+        assert_eq!(
+            author.fg,
+            Some(theme.author_color),
+            "non-lane author keeps its own color: {author:?}"
+        );
     }
 
     /// The full rendered text of a row (all spans concatenated).
@@ -4045,7 +4262,7 @@ mod tests {
             [((a, a), a)].into_iter().collect();
 
         let mut spans: Vec<Span> = Vec::new();
-        render_cells_unicode(&mut spans, &node, &theme, 0, 8, Some(&lit), false);
+        render_cells_unicode(&mut spans, &node, &theme, 0, 8, Some(&lit), false, None);
 
         let commit = spans.iter().find(|s| s.content.contains('●')).unwrap();
         let pipe = spans.iter().find(|s| s.content.contains('│')).unwrap();
@@ -4065,10 +4282,59 @@ mod tests {
         let mut node = node_with_cells(vec![CellType::Commit(0), CellType::Pipe(1)], false);
         node.cell_oids = vec![(Some((oid(1), oid(1))), None), (Some((oid(2), oid(2))), None)];
         let mut spans: Vec<Span> = Vec::new();
-        render_cells_unicode(&mut spans, &node, &theme, 0, 8, None, false);
+        render_cells_unicode(&mut spans, &node, &theme, 0, 8, None, false, None);
         assert!(spans
             .iter()
             .all(|s| !s.style.add_modifier.contains(Modifier::DIM)));
+    }
+
+    #[test]
+    fn merged_lane_dims_only_merged_cells_in_unicode() {
+        // A cell whose edge touches a merged-lane commit dims; a trunk cell
+        // (no merged endpoint) stays bright — the same per-cell rule as tracing,
+        // driven off the merged-lane set instead of the trace lit set (#108).
+        let theme = Theme::dark();
+        let (m, t) = (oid(4), oid(3));
+        let mut node = node_with_cells(vec![CellType::Commit(0), CellType::Pipe(1)], false);
+        // Dot self-edge belongs to the merged commit; the pipe is a trunk pipe.
+        node.cell_oids = vec![(Some((m, m)), None), (Some((t, t)), None)];
+        let merged: HashSet<git2::Oid> = [m].into_iter().collect();
+
+        let mut spans: Vec<Span> = Vec::new();
+        render_cells_unicode(&mut spans, &node, &theme, 0, 8, None, false, Some(&merged));
+
+        let dot = spans.iter().find(|s| s.content.contains('●')).unwrap();
+        let pipe = spans.iter().find(|s| s.content.contains('│')).unwrap();
+        assert!(
+            dot.style.add_modifier.contains(Modifier::DIM),
+            "merged-lane commit dot dims"
+        );
+        assert!(
+            !pipe.style.add_modifier.contains(Modifier::DIM),
+            "a trunk pipe with no merged endpoint stays bright"
+        );
+    }
+
+    #[test]
+    fn merged_lane_dim_composes_with_trace_in_unicode() {
+        // Merged-lane dim ORs with trace: a merged-lane cell dims even when the
+        // trace would light it, so a selected merged branch still recedes.
+        let theme = Theme::dark();
+        let m = oid(4);
+        let mut node = node_with_cells(vec![CellType::Commit(0)], false);
+        node.cell_oids = vec![(Some((m, m)), None)];
+        let lit: std::collections::HashMap<crate::git::graph::CellEdge, git2::Oid> =
+            [((m, m), m)].into_iter().collect();
+        let merged: HashSet<git2::Oid> = [m].into_iter().collect();
+
+        let mut spans: Vec<Span> = Vec::new();
+        render_cells_unicode(&mut spans, &node, &theme, 0, 8, Some(&lit), false, Some(&merged));
+
+        let dot = spans.iter().find(|s| s.content.contains('●')).unwrap();
+        assert!(
+            dot.style.add_modifier.contains(Modifier::DIM),
+            "merged-lane dim wins even when tracing lights the cell"
+        );
     }
 
     #[test]
@@ -4207,7 +4473,7 @@ mod tests {
         let (base, oids, lit, lane_rgb) = window_dim_fixture(10);
         let ro = row_oids_of(&oids);
         let ff = no_force(base.len());
-        let out = dim_specs_window_core(&base, &ro, &ff, &lit, &lane_rgb, 3, 7);
+        let out = dim_specs_window_core(&base, &ro, &ff, &lit, &lane_rgb, None, 3, 7);
 
         assert_eq!(out.len(), base.len(), "result keeps full length");
         for (i, spec) in out.iter().enumerate() {
@@ -4232,8 +4498,8 @@ mod tests {
         let (base, oids, lit, lane_rgb) = window_dim_fixture(12);
         let ro = row_oids_of(&oids);
         let ff = no_force(base.len());
-        let full = dim_specs_window_core(&base, &ro, &ff, &lit, &lane_rgb, 0, base.len());
-        let windowed = dim_specs_window_core(&base, &ro, &ff, &lit, &lane_rgb, 4, 9);
+        let full = dim_specs_window_core(&base, &ro, &ff, &lit, &lane_rgb, None, 0, base.len());
+        let windowed = dim_specs_window_core(&base, &ro, &ff, &lit, &lane_rgb, None, 4, 9);
         for i in 4..9 {
             assert_eq!(windowed[i], full[i], "row {i} matches the full-range dim");
         }
@@ -4244,7 +4510,7 @@ mod tests {
         let (base, oids, lit, lane_rgb) = window_dim_fixture(5);
         let ro = row_oids_of(&oids);
         let ff = no_force(base.len());
-        let out = dim_specs_window_core(&base, &ro, &ff, &lit, &lane_rgb, 2, 2);
+        let out = dim_specs_window_core(&base, &ro, &ff, &lit, &lane_rgb, None, 2, 2);
         assert_eq!(out.len(), 5);
         assert!(out.iter().all(|s| s.cells.is_empty()));
     }
@@ -4260,7 +4526,7 @@ mod tests {
         // Row 2 is a base-update merge; the rest are ordinary rows.
         let mut ff = no_force(base.len());
         ff[2] = true;
-        let out = dim_specs_window_core(&base, &ro, &ff, &lit, &lane_rgb, 0, base.len());
+        let out = dim_specs_window_core(&base, &ro, &ff, &lit, &lane_rgb, None, 0, base.len());
 
         // Row 2's connector is fully dimmed by force-dim...
         assert!(
@@ -4271,6 +4537,63 @@ mod tests {
         // ...even though row 2 is an EVEN row that trace dimming would leave lit —
         // force-dim wins over trace, mirroring the unicode `force_dim || trace`.
         assert!(!out[0].cells[0].dim, "non-forced even row 0 stays lit by trace");
+    }
+
+    #[test]
+    fn merged_lane_dims_touching_pixel_cells_only() {
+        // With tracing off (empty lit) and a merged-lane set supplied, only the
+        // cells whose edge touches a merged commit dim — the rest stay bright.
+        // The fixture's even rows carry edge (oid(2),oid(2)); odd rows (oid(9)…).
+        let (base, oids, _lit, _rgb) = window_dim_fixture(4);
+        let ro = row_oids_of(&oids);
+        let ff = no_force(base.len());
+        let empty_lit = std::collections::HashMap::new();
+        let empty_rgb = std::collections::HashMap::new();
+        let merged: HashSet<git2::Oid> = [oid(2)].into_iter().collect();
+
+        let out = dim_specs_window_core(
+            &base,
+            &ro,
+            &ff,
+            &empty_lit,
+            &empty_rgb,
+            Some(&merged),
+            0,
+            base.len(),
+        );
+
+        for (i, spec) in out.iter().enumerate().take(4) {
+            // Even rows touch oid(2) -> dim; odd rows have no merged endpoint and
+            // must stay bright — proving the empty-lit trace pass is skipped
+            // (otherwise it would dim every cell).
+            assert_eq!(
+                spec.cells[0].dim,
+                i % 2 == 0,
+                "row {i} merged-lane dim: {:?}",
+                spec.cells
+            );
+        }
+    }
+
+    #[test]
+    fn trace_off_leaves_pixel_specs_bright() {
+        // Regression guard for the empty-lit fix: with no trace, no force-dim,
+        // and no merged-lane set, dimming is a no-op — every base cell stays
+        // bright (the trace pass must not dim everything when nothing is lit).
+        let (base, oids, _lit, _rgb) = window_dim_fixture(4);
+        let ro = row_oids_of(&oids);
+        let ff = no_force(base.len());
+        let empty_lit = std::collections::HashMap::new();
+        let empty_rgb = std::collections::HashMap::new();
+
+        let out = dim_specs_window_core(
+            &base, &ro, &ff, &empty_lit, &empty_rgb, None, 0, base.len(),
+        );
+
+        assert!(
+            out.iter().all(|s| s.cells.iter().all(|c| !c.dim && !c.dim_secondary)),
+            "no dim source active: all cells stay bright"
+        );
     }
 
     #[test]
@@ -4328,7 +4651,7 @@ mod tests {
 
         // Tracing lights only the trunk: the spoke cell dims → so must the tail.
         let lit_trunk = [(trunk_edge, oid(3))].into_iter().collect();
-        let out = dim_specs_window_core(&base, &ro, &ff, &lit_trunk, &HashMap::new(), 0, 2);
+        let out = dim_specs_window_core(&base, &ro, &ff, &lit_trunk, &HashMap::new(), None, 0, 2);
         assert!(out[0].cells[2].dim, "spoke cell dims off-lineage");
         assert!(out[1].incoming[0].dim, "tail dims with its source spoke");
 
@@ -4336,7 +4659,7 @@ mod tests {
         let red = [255u8, 0, 0];
         let lit_branch = [(branch_edge, oid(2))].into_iter().collect();
         let lane_rgb = [(oid(2), red)].into_iter().collect();
-        let out = dim_specs_window_core(&base, &ro, &ff, &lit_branch, &lane_rgb, 0, 2);
+        let out = dim_specs_window_core(&base, &ro, &ff, &lit_branch, &lane_rgb, None, 0, 2);
         assert!(!out[1].incoming[0].dim, "lit tail stays bright");
         assert_eq!(out[1].incoming[0].color, red, "tail takes the spoke's traced color");
     }
@@ -4367,7 +4690,7 @@ mod tests {
 
         let mut spans: Vec<Span> = Vec::new();
         // cap = 3 leaves room for 2 glyphs plus the `…` marker.
-        render_cells_unicode(&mut spans, &node, &theme, 0, 3, Some(&lit), false);
+        render_cells_unicode(&mut spans, &node, &theme, 0, 3, Some(&lit), false, None);
 
         let commit = spans.iter().find(|s| s.content.contains('●')).unwrap();
         assert!(!commit.style.add_modifier.contains(Modifier::DIM));

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -391,7 +391,12 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
         // while the message muted).
         let want_base_mute = app.metadata_columns.mute_base_merges
             && !app.merged.base_update.value().is_empty();
-        pixel_frame_dim = if trace_active || want_base_mute {
+        // Merged-lane dim (#108) is a third per-frame dim source: build the
+        // overlay whenever merged branches are shown-and-dimmed, even with
+        // tracing and base-mute off.
+        let want_merged_lane_dim =
+            app.merged.dim && !app.merged.hide && !app.merged.lane_oids.is_empty();
+        pixel_frame_dim = if trace_active || want_base_mute || want_merged_lane_dim {
             let base = &app.pixel_specs_cache.as_ref().unwrap().4;
             Some(graph_view::dim_pixel_specs_window(
                 app,


### PR DESCRIPTION
Extends the "Dim merged branches" setting (#106) so it dims the whole lane of every merged branch, not just the chip/badge. When dim is on and hide-merged is off, every commit exclusive to a merged branch's lane renders dimmed: the message + hash/author/date metadata AND the graph dots/lines of that lane.

## Design
- **Commit selection mirrors hide-merged (#91).** `graph::merged_lane_oids` is a pure walk over the already-loaded commits — `reachable(merged tips)` minus the first-parent chains of the live (non-merged) refs + HEAD — i.e. exactly the commits that would vanish if hide-merged were toggled on. Squash/merge-commit branches dim; trunk, unmerged, and fast-forwarded-onto-trunk branches don't. Stored on `App.merged.lane_oids`, recomputed on every graph rebuild.
- **Instant toggle.** `lane_oids` is populated whenever merged branches exist; the render path gates on `dim && !hide`, so flipping the setting reflects immediately without a rebuild (same as the badge).
- **Row text.** Merged-lane commits fold into `row_is_muted` (#92): `fg(text_muted)` on message + metadata, DIM on the message. Composes with existing muting.
- **Both renderers, each in its own idiom.** Unicode: per-cell dim for strokes whose edge touches a merged-lane commit (`cell_touches_merged`), composing with force-dim/trace. Pixel: `apply_merged_lane_dim` feeds the dim-spec machinery as a third source.
- **Latent fix.** The pixel trace pass dimmed *every* cell when tracing was off (empty lit map); it now runs only when tracing is active, restoring the documented "no dim when tracing off" contract that base-mute — and now merged-lane dim — rely on.
- The #81 squash link line is untouched. No new setting.

## Tests
Pure selection fn (merged/squash in, trunk/unmerged/ff out), edge/cell touch predicates, row-text greying + toggle-off + non-lane-stays-bright, unicode per-cell dim + trace composition, pixel per-cell dim, and a trace-off-stays-bright regression guard. `cargo test` (1186 passed) and `cargo clippy --all-targets` (clean).

## Live check
Ran the TUI against the repo's two real squash-merged branches (`feat/ctrl-home-top`, `feat/settings-fuzzy-filter`): with dim on both lanes/rows are present with the merged badge; toggling dim off leaves the 24 visible commit rows byte-identical (no commits added/removed, unlike hide-merged). Color assertions are covered by the style-level unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FhXidvo7reDeAMi4M6B6JP