### PR TITLE
feat(graph): hide-stashes toggle

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -603,6 +603,9 @@ Bug: the #81 grey squash-link connector rendered as two curves aimed at a phanto
 ### [DONE] #108 Dim merged branches dims the whole lane
 "Dim merged branches" dims everything a merged branch contributes — its exclusive commits' rows (message + metadata) and the graph dots/lines — in both renderers, gated on the existing setting; instant toggle, composes with trace dim. Landed via PR #86. Also fixed latent pixel bug: the trace pass dimmed every cell when tracing was off.
 
+### [DONE] #118 Hide-stashes toggle (GH #100)
+New "Hide stashes" setting (Graph group, state-only, default off — stashes stay visible). Mirrors "Hide remote branches" end-to-end: descriptor, `UiState` field, App field, init/refresh projection. Filters at the App layer by passing an empty stash slice into `get_commits` + `build_graph`, so the stash node and any commit reachable only as a stash parent vanish together; when off the graph is byte-identical. Settings-panel-only (no new keybinding).
+
 ### [DONE] #117 Branch-chip click targets recorded at construction (GH #98)
 Found by the #102 seam-pinning tests: `resolve_chip_branch` recovered the click target by parsing the rendered label, so an abbreviated (`...`) label — or one whose name collides with the chip's own delimiters — resolved to `None` and the click silently did nothing. Now each `BranchChip` records the source ref at its construction site (`optimize_branch_display` builds chips directly; the parsing helper is deleted): abbreviation and decoration are presentation-only and can never break hit-testing. Combined multi-branch chips keep their pre-existing target (first shown branch).
 

--- a/src/app/init.rs
+++ b/src/app/init.rs
@@ -67,7 +67,14 @@ impl App {
         let head_name = repo.head_name();
         let head_detached = repo.is_head_detached();
 
-        let stashes = repo.get_stashes();
+        // The hide-stashes toggle is persisted; honour it here so stash entries
+        // (and stash-only commits) don't flash before the next refresh. An empty
+        // slice keeps the graph build byte-identical to a repo with no stashes.
+        let stashes = if ui_state.hide_stashes {
+            Vec::new()
+        } else {
+            repo.get_stashes()
+        };
         phase!("stashes");
         // The per-branch picker hides nothing at startup, but the show/hide-
         // remotes toggle is persisted, so honour it here to avoid a first-frame
@@ -262,6 +269,7 @@ impl App {
             last_undoable_op: None,
             side_panel_layout: ui_state.side_panel_layout,
             hide_remote_branches: ui_state.hide_remote_branches,
+            hide_stashes: ui_state.hide_stashes,
             merged: MergedState {
                 branches: merged_branches,
                 squash_targets,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1112,6 +1112,10 @@ pub struct App {
     /// commits. Composes with `hidden_branches`. Persisted in `UiState`.
     pub hide_remote_branches: bool,
 
+    /// When true, stash entries (and any commits reachable only as stash
+    /// parents) are hidden from the graph. Persisted in `UiState`.
+    pub hide_stashes: bool,
+
     // Which metadata columns (author/hash/date) render on each commit row.
     pub metadata_columns: crate::config::MetadataColumns,
 
@@ -1763,8 +1767,9 @@ impl App {
 
     /// Write one setting's new value to the live app state, persist it, and
     /// rebuild the graph if the change was one a bare field write can't realize
-    /// on its own — the branch visibility toggles (`hide_remote_branches` /
-    /// `hide_merged_branches`), which change which commits are in the graph.
+    /// on its own — the branch/stash visibility toggles (`hide_remote_branches` /
+    /// `hide_merged_branches` / `hide_stashes`), which change which commits are
+    /// in the graph.
     fn commit_setting(
         &mut self,
         descriptor: &crate::settings::SettingDescriptor,
@@ -1772,11 +1777,13 @@ impl App {
     ) -> Result<()> {
         let old_hide_remote = self.hide_remote_branches;
         let old_hide_merged = self.merged.hide;
+        let old_hide_stashes = self.hide_stashes;
         let old_squash_links = self.config.ui.squash_link_lines;
         descriptor.set(self, value);
         self.persist_settings();
         if self.hide_remote_branches != old_hide_remote
             || self.merged.hide != old_hide_merged
+            || self.hide_stashes != old_hide_stashes
             || self.config.ui.squash_link_lines != old_squash_links
         {
             // These change which commits (or synthetic link lines) the graph

--- a/src/app/refresh.rs
+++ b/src/app/refresh.rs
@@ -340,7 +340,14 @@ impl App {
     /// Must NOT touch: the selection index or the diff/search caches. May fail
     /// if the revwalk fails.
     fn rebuild_graph(&mut self) -> Result<()> {
-        let stashes = self.repo.get_stashes();
+        // Hide-stashes filters at the source: an empty slice pushes no stash
+        // tips into the revwalk (so stash-only commits vanish) and yields no
+        // stash nodes in `build_graph`. When off, the graph is byte-identical.
+        let stashes = if self.hide_stashes {
+            Vec::new()
+        } else {
+            self.repo.get_stashes()
+        };
         let uncommitted_count = self
             .working_tree_status
             .as_ref()

--- a/src/config.rs
+++ b/src/config.rs
@@ -326,6 +326,9 @@ pub struct UiState {
     /// Group the files pane by folder (`f` toggles). Off by default: files list
     /// flat with full repo-relative paths, the historical behavior.
     pub files_group_by_folder: bool,
+    /// Hide stash entries (and any commits reachable only as stash parents) from
+    /// the graph. Off by default (stashes shown), preserving historical behavior.
+    pub hide_stashes: bool,
     pub metadata_columns: MetadataColumns,
 }
 
@@ -341,6 +344,7 @@ impl Default for UiState {
             hide_merged_branches: false,
             dim_merged_branches: true,
             files_group_by_folder: false,
+            hide_stashes: false,
             metadata_columns: MetadataColumns::default(),
         }
     }
@@ -562,6 +566,7 @@ mod tests {
             hide_merged_branches: false,
             dim_merged_branches: false,
             files_group_by_folder: true,
+            hide_stashes: false,
             metadata_columns: MetadataColumns {
                 author: true,
                 hash: false,
@@ -683,6 +688,23 @@ mod tests {
         };
         let restored: UiState = toml::from_str(&toml::to_string(&wrapped).unwrap()).unwrap();
         assert!(restored.diff_word_wrap);
+    }
+
+    #[test]
+    fn hide_stashes_defaults_off_and_round_trips() {
+        // Stashes are shown by default, including for an older state.toml that
+        // predates the key.
+        assert!(!UiState::default().hide_stashes);
+        let older: UiState = toml::from_str("side_panel_layout = true").unwrap();
+        assert!(!older.hide_stashes, "missing key defaults to shown");
+
+        // Once set, the preference survives a save/load round-trip.
+        let hidden = UiState {
+            hide_stashes: true,
+            ..UiState::default()
+        };
+        let restored: UiState = toml::from_str(&toml::to_string(&hidden).unwrap()).unwrap();
+        assert!(restored.hide_stashes);
     }
 
     #[test]

--- a/src/debug_server.rs
+++ b/src/debug_server.rs
@@ -271,6 +271,7 @@ fn state_json(app: &App) -> Value {
         // Settings-menu-managed flags, exposed so tests can assert persistence
         // across restarts.
         "hide_remote_branches": app.hide_remote_branches,
+        "hide_stashes": app.hide_stashes,
         "trace_enabled": app.trace_enabled,
         "diff_word_wrap": app.diff_word_wrap,
         "graph_renderer": app.config.ui.graph_renderer.as_str(),

--- a/src/git/repository.rs
+++ b/src/git/repository.rs
@@ -559,6 +559,65 @@ mod tests {
         );
     }
 
+    #[test]
+    fn hide_stashes_drops_stash_node_and_stash_only_commits() {
+        // The hide-stashes toggle filters at the App layer by passing an empty
+        // stash slice into get_commits + build_graph. This asserts that altitude:
+        // an empty slice removes the stash node AND any commit reachable only as
+        // a stash parent, while the populated slice keeps both.
+        use crate::git::graph::build_graph;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let local = tmp.path().join("local");
+        Command::new("git").args(["init", "-q", "-b", "main"]).arg(&local).status().unwrap();
+        git(&local, &["config", "user.email", "t@t.com"]);
+        git(&local, &["config", "user.name", "t"]);
+        std::fs::write(local.join("a.txt"), "a").unwrap();
+        git(&local, &["add", "a.txt"]);
+        git(&local, &["commit", "-qm", "c1"]);
+        std::fs::write(local.join("a.txt"), "a2").unwrap();
+        git(&local, &["add", "a.txt"]);
+        git(&local, &["commit", "-qm", "STASH-BASE-COMMIT"]);
+        // Stash a working-tree change (its base is STASH-BASE-COMMIT), then roll
+        // main back one commit so STASH-BASE-COMMIT is reachable ONLY via the
+        // stash's parent — i.e. a stash-only commit.
+        std::fs::write(local.join("a.txt"), "dirty").unwrap();
+        git(&local, &["stash", "push", "-q", "-m", "wip"]);
+        git(&local, &["reset", "-q", "--hard", "HEAD~1"]);
+
+        let mut repo = GitRepository::open(&local).unwrap();
+        let branches = repo.get_branches().unwrap();
+        let tags = repo.get_tags();
+        let head = repo.head_oid();
+        let stashes = repo.get_stashes();
+        assert_eq!(stashes.len(), 1, "one stash expected");
+
+        // Stashes shown: the stash node and the stash-only base commit appear.
+        let commits = repo.get_commits(50, &branches, &stashes, false).unwrap();
+        assert!(
+            commits.iter().any(|c| c.message.contains("STASH-BASE-COMMIT")),
+            "stash-only base commit must be walked when stashes are shown"
+        );
+        let shown = build_graph(&commits, &branches, &tags, &stashes, None, head, &[]);
+        assert!(
+            shown.nodes.iter().any(|n| n.is_stash),
+            "a stash node must be present when stashes are shown"
+        );
+
+        // Stashes hidden (empty slice — the App gate): no stash node, and the
+        // stash-only commit is gone since nothing else reaches it.
+        let commits_hidden = repo.get_commits(50, &branches, &[], false).unwrap();
+        assert!(
+            !commits_hidden.iter().any(|c| c.message.contains("STASH-BASE-COMMIT")),
+            "stash-only commit must vanish when stashes are hidden"
+        );
+        let hidden = build_graph(&commits_hidden, &branches, &tags, &[], None, head, &[]);
+        assert!(
+            !hidden.nodes.iter().any(|n| n.is_stash),
+            "no stash node may remain when stashes are hidden"
+        );
+    }
+
     /// Builds a repo with `main` and a `feature` branch merged into `main` via
     /// a real (non-fast-forward) merge commit, plus a second, unmerged
     /// `other-feature` branch. Returns the working dir path.

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -354,6 +354,7 @@ pub fn descriptors() -> Vec<SettingDescriptor> {
             merged.dim,
             dim_merged_branches
         ),
+        state_bool!("Hide stashes", Graph, None, hide_stashes, hide_stashes),
         state_bool!(
             "Mute merge commits",
             Graph,
@@ -598,6 +599,7 @@ mod tests {
             hide_merged_branches: true,
             dim_merged_branches: false,
             files_group_by_folder: true,
+            hide_stashes: true,
             metadata_columns: MetadataColumns {
                 author: false,
                 hash: false,


### PR DESCRIPTION
## Summary

Adds a **"Hide stashes"** setting (Graph group, state-only, default **off** so stashes stay visible — current behavior preserved). Mirrors the existing "Hide remote branches" setting end-to-end.

## The setting

- Descriptor: `state_bool!("Hide stashes", Graph, ...)` in `src/settings.rs`, placed after "Dim merged branches".
- Persisted on `UiState.hide_stashes` (state.toml), projected to `App.hide_stashes` at init and read on every refresh.
- Settings-panel-only — no new keybinding (matches the task constraint; `hide_remote_branches` has a keybinding but the merged/remote hide toggles are not exposed in the command palette, so nothing to mirror there).

## Application point

Filters at the **App layer** where the stash list is fetched (`src/app/refresh.rs` `rebuild_graph`, and `src/app/init.rs` `build`): when the toggle is on, an **empty stash slice** is passed into `get_commits` (no stash tips pushed into the revwalk) and `build_graph` (no `is_stash` nodes). This makes the stash node **and** any commit reachable only as a stash parent disappear together, naturally. With the toggle off the empty-vs-populated slice is the only difference, so the graph is byte-identical to before.

Toggling through the settings panel triggers a rebuild via `commit_setting` (the same path as `hide_remote_branches` / `hide_merged_branches`), so it applies instantly.

## Tests

- `config::tests::hide_stashes_defaults_off_and_round_trips` — defaults off; missing key in an older state.toml defaults to shown; round-trips through save/load.
- `settings::tests::state_settings_persistence_round_trips_every_ui_state_field` — extended with `hide_stashes` so the registry read/write lenses cover the new field.
- `git::repository::tests::hide_stashes_drops_stash_node_and_stash_only_commits` — real-repo test: a stash whose base commit is reachable only via the stash. Populated slice → `build_graph` yields an `is_stash` node and the stash-only base commit is walked; empty slice (the App gate) → no stash node and the stash-only commit is gone.

`cargo test`: 872 lib tests + integration suites pass, 0 failures. `cargo clippy --all-targets`: clean.

## Live-TUI verification

Launched the real TUI (via `--debug-listen`) against a throwaway repo with `stash@{0}: On main: my-wip-stash`:

- **Off (default):** graph shows the `{stash@{0}} On main: my-wip-stash` row + its lane merge line; `commit_count 4`, `node_count 5`.
- **Toggled on** (Ctrl+, → Hide stashes → Space): stash row and its lane line gone, clean linear graph; `hide_stashes:true`, `commit_count 3`, `node_count 3`.
- **Toggled back off:** stash row reappears instantly; state returns to `commit_count 4`, `node_count 5`.

Stacked on #99 — merge #99 first; this PR's diff reduces to the stash toggle once #99 lands.

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EzeThF8q4rK6CcqYEVscqD