### PR TITLE
docs: rewrite CLAUDE.md — drop cruft, keep protocol and load-bearing decisions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,72 +1,28 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
-
-## Project Overview
-
-keifu (系譜) is a Rust TUI for git graph visualization, aiming for a VSCode-like Git Graph + Source Control experience in the terminal. Built with Ratatui + Crossterm for rendering, git2 (libgit2) for git operations.
-
-## Build & Development Commands
-
-```bash
-cargo build              # Build
-cargo check              # Fast type-check (use during development)
-cargo test               # Run all tests
-cargo test <test_name>   # Run a single test
-cargo clippy             # Lint
-cargo run                # Run against current directory's git repo
-cargo run -- /path/to   # Run against a specific repo
-```
+keifu (系譜) is a Rust TUI for git graph visualization — a VSCode-like Git Graph + Source Control experience in the terminal. Ratatui + Crossterm for rendering, git2 (libgit2) for git operations. `cargo run -- /path/to/repo` runs against a specific repo (defaults to cwd).
 
 ## Workflow
 
-Track work in GitHub Issues — `gh issue list` / `gh issue create`. (`docs/TODO.md` is a historical log; do not add new entries to it.)
-
-When implementing features or fixes:
-1. Create (or reference) a GitHub issue
-2. Create a new git branch — never commit directly to `chong-dev`
-3. Write unit tests where appropriate
-4. Implement the feature
-5. Ensure `cargo test` and `cargo clippy` pass
-6. Push and open a PR against `chong-dev` (`gh pr create`, body `Closes #N`); land it with a squash merge
-7. Document architectural decisions or gotchas in `docs/`
+- Track work in GitHub Issues (`gh issue create`). `docs/TODO.md` is a historical log — do not add new entries.
+- Never commit directly to `chong-dev`. Branch → PR (`gh pr create --base chong-dev`, body `Closes #N`) → squash merge. Keep `main` fast-forwarded from `chong-dev`.
+- `cargo test` and `cargo clippy` must pass before a PR.
+- Changes with visible TUI behavior get verified in the real app (debug server: `--debug-listen`, see `docs/debugging.md`), not only through unit tests.
+- Architectural decisions and gotchas go in `docs/architecture.md` when they land.
 
 ## Architecture
 
-### Data Flow
+Event loop in `main.rs`: render → poll input → `keybindings.rs` maps keys to `Action` variants (routes on `AppMode` × `FocusedPanel`, no business logic) → `app/` handles the action (all state lives on `App`) → `ui/` widgets render statelessly from `&App`. `git/` wraps git2; `git/graph.rs` builds the visual layout. Full map and history: `docs/architecture.md`.
 
-Event loop in `main.rs`: render frame → poll input → `map_key_to_action()` → `app.handle_action()` → update state → next frame.
+## Load-bearing decisions
 
-### Key Modules
+Constraints whose violation has caused real bugs — the code shows *what*, this records *why*:
 
-- **`app.rs`** — Central state machine. All application state lives on the `App` struct. Handles actions dispatched by the keybinding layer. This is the largest file and the integration point for everything.
-- **`git/`** — Git abstraction layer. `repository.rs` wraps git2::Repository. `diff.rs` computes diffs (staged/unstaged/committed). `operations.rs` has all mutating git commands. `graph.rs` builds the visual graph layout from commits.
-- **`ui/`** — Stateless rendering widgets. Each widget receives `&App` or relevant data and renders to a Ratatui frame. `mod.rs` has the top-level `draw()` function that composes the layout.
-- **`keybindings.rs`** — Maps key events to `Action` variants. Routes based on both `AppMode` and `FocusedPanel`. This is the input layer — no business logic here.
-- **`action.rs`** — Enum of all user actions. Decouples input mapping from action handling.
-- **`text_editor.rs`** — Multi-line text editor with cursor, selection, word navigation. Used for commit message editing.
-- **`config.rs`** — TOML config from `~/.config/keifu/config.toml`. Controls auto-refresh/fetch intervals.
-
-### Key Design Decisions (see `docs/architecture.md` for full context)
-
-- **Panel focus is orthogonal to mode.** `FocusedPanel` (Graph/Files/CommitDetail) is a field on `App`, not a mode variant. Modes (`Normal`, `Help`, `Input`, `Confirm`, `FileDiff`, etc.) overlay on top. The keybinding router checks both.
-- **Two-tier diff caching.** Quick cache (synchronous, file names from `diff.deltas()`) shows instantly. Full cache (async, line stats) loads with 120ms debounce. `cached_diff_or_quick()` returns the best available. Gotcha: uncommitted diff-load errors latch (`uncommitted_diff_error_reported`) and won't re-report until an episode boundary (success, or `clear_uncommitted()`) — don't expect every failed poll to surface a fresh message.
-- **`refresh_after_file_op()`** — After file operations (stage/gitignore/archive/trash), uses `invalidate_uncommitted_diff_cache()` (keeps stale data visible) + immediate quick-diff recomputation to avoid UI flash.
-- **TextEditor lives on `App.commit_editor`**, not in a mode variant, so commit messages survive panel focus changes.
-- **Clipboard uses shell commands** (`xclip`/`xsel`/`wl-copy`/`pbcopy`) to avoid openssl-sys build issues, falling back to an OSC 52 escape sequence (`tui::copy_to_clipboard_osc52`) when no shell tool is found.
-- **git2 ignore cache** — `repo.clear_ignore_rules()` is called before status queries so `.gitignore` edits take effect without restarting.
-- **Settings persistence via a pure registry.** `src/settings.rs` has no `App` dependency (descriptors + get/set accessors); `App::settings_model()`/`apply_settings_model()` project to/from `App` state. State-only settings save through `UiState::save()` to `state.toml`; config-file settings save through `toml_edit`, rewriting only touched keys so comments and unknown keys survive.
-- **Toasts for one-shot events, status bar for persistent state.** `ToastQueue` (`src/toast.rs`) handles transient outcomes (Info/Success/Error, TTL-based, capped at 3 visible). The status bar stays reserved for sticky state: in-flight network progress, conflict guidance, and latched periodic errors — a background check that fails repeatedly reports once per failure episode (set on first failure, cleared on success), not on every poll.
-
-### AppMode variants
-
-`Normal` | `Help` | `Input` (create branch, tag, search) | `Confirm` (destructive ops) | `CommitMenu` | `BranchFilter` | `FileDiff` (full diff viewer with syntax highlighting)
-
-There is no error mode: one-shot errors are red toasts (12s TTL, Esc dismisses; #116) — no error may block input.
-
-### File operations on uncommitted changes
-
-`s` stage/unstage | `r` restore (discard changes) | `i` gitignore | `v` archive to `.archive/` | `Delete` trash untracked (recycle bin) | `Ctrl+Z` undo last op | `Space` open file | `f` toggle folder grouping | `Ctrl+F` filter
+- **Panel focus is orthogonal to mode.** `FocusedPanel` is a field on `App`, not a mode variant; modes overlay it. Same reason `TextEditor` lives on `App.commit_editor`: commit messages must survive focus changes.
+- **Errors are red toasts, never blocking.** There is no error mode; no error may swallow input. Toasts are for one-shot outcomes; the status bar is reserved for sticky state (network progress, conflict guidance, latched periodic errors — reported once per failure episode, not per poll).
+- **Two-tier diff caching.** Quick cache (sync, names only) shows instantly; full cache loads async with debounce. Uncommitted diff-load errors latch per episode — do not expect every failed poll to surface a fresh message. After file ops, caches are invalidated (stale data stays visible) and the quick diff recomputes synchronously — this is deliberate anti-flash design, not staleness to fix.
+- **Settings go through the pure registry** in `src/settings.rs` (no `App` dependency). State-only settings persist via `UiState` to `state.toml`; config-file settings rewrite only touched keys through `toml_edit` so user comments survive.
+- **The unicode and pixel dim/render paths are deliberately parallel implementations** (see comments in `ui/graph_view/`). Do not unify them.
+- **Clipboard uses shell tools with an OSC 52 fallback** — no clipboard crate (avoids openssl-sys build breakage).
 
 Fix root causes, not symptoms. Avoid band-aids like stopPropagation, setTimeout, or flags to mask bugs.
-

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,16 +20,16 @@ cargo run -- /path/to   # Run against a specific repo
 
 ## Workflow
 
+Track work in GitHub Issues — `gh issue list` / `gh issue create`. (`docs/TODO.md` is a historical log; do not add new entries to it.)
+
 When implementing features or fixes:
-1. Create an entry in `docs/TODO.md`
-2. Create a new git branch
+1. Create (or reference) a GitHub issue
+2. Create a new git branch — never commit directly to `chong-dev`
 3. Write unit tests where appropriate
 4. Implement the feature
 5. Ensure `cargo test` and `cargo clippy` pass
-6. Merge the branch, mark the issue in `docs/TODO.md` as done
+6. Push and open a PR against `chong-dev` (`gh pr create`, body `Closes #N`); land it with a squash merge
 7. Document architectural decisions or gotchas in `docs/`
-
-Use GitHub Issues for tracking — `gh issue list` / `gh issue create`.
 
 ## Architecture
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,9 +4,9 @@
 
 **Decision:** `FocusedPanel` is a field on `App`, not a new `AppMode` variant.
 
-**Why:** The existing `FileSelect` and `FileDiff` modes work as overlays on top of the graph view. If we made panel focus a mode, we'd need to handle mode transitions between `FileSelect`, `FileDiff`, and each panel focus state — an explosion of combinations. Keeping focus as a field means modes and panel focus are orthogonal.
+**Why:** The `FileDiff` mode and the various popups work as overlays on top of the graph/files panes. If we made panel focus a mode too, we'd need to handle mode transitions between every overlay and each panel focus state — an explosion of combinations. Keeping focus as a field (`FocusedPanel::{Graph, Files, CommitDetail}`) means modes and panel focus are orthogonal.
 
-**How it works:** The keybinding router checks both `app.mode` and `app.focused_panel` to determine which key handler to use. In `AppMode::Normal`, keys are routed to `handle_graph_action`, `handle_files_action`, or `handle_commit_detail_action` based on focused panel. Other modes (Help, Input, Confirm, CommitMenu, FileSelect, FileDiff) handle their own keys regardless of focused panel.
+**How it works:** The keybinding router checks both `app.mode` and `app.focused_panel` to determine which key handler to use. In `AppMode::Normal`, keys are routed to `handle_graph_action`, `handle_files_action`, or `handle_commit_detail_action` based on focused panel. The files pane is the `Files` focused panel, not a mode. Other modes (Help, Input, Confirm, CommitMenu, FileDiff, and the menu/popup modes) handle their own keys regardless of focused panel.
 
 ## Text Editor Persistence (2026-03-25)
 
@@ -158,9 +158,9 @@ xterm-256 palette formula) so rasterization has concrete colors.
 shifts render as VSCode-style cubic Bézier S-curves rather than a straight
 horizontal run + a tight rounded corner. `draw_cells` (`src/ui/graph_pixels.rs`)
 runs in two phases:
-1. `transition_curves` (~line 606) — a pure, row-local scan of `spec.cells` —
+1. `transition_curves` (~line 908) — a pure, row-local scan of `spec.cells` —
    reconstructs each maximal horizontal-family run into cubics via
-   `cubic_between` (~line 580). A run's endpoints are its corners/Tees plus any
+   `cubic_between` (~line 863). A run's endpoints are its corners/Tees plus any
    flanking commit dot, classified as *hubs* (row mid-height: a flanking dot,
    or a `TeeRight`/`TeeLeft` that stays on the trunk with no flanking dot — a
    fork connector's trunk, whose up-arms fan from it) or *spokes* (a row edge:
@@ -175,7 +175,7 @@ runs in two phases:
    carries the spoke's own flat color/dim for its entire sweep, so a
    multi-color fork connector colors each arm correctly.
 
-   `cubic_between(a, b)` (~line 580) places **both** control points at the
+   `cubic_between(a, b)` (~line 863) places **both** control points at the
    endpoints' shared y-midpoint — `(a.x, ymid)` and `(b.x, ymid)` — rather than
    at a hand-tuned hub-tilt/fan offset. That makes every curve leave and enter
    *every* endpoint travelling vertically, so its tangent matches the straight
@@ -267,32 +267,41 @@ merged-branch set is not wiped), so a transient gh error can't blank the badges.
 
 ## Settings Registry (2026-07-20)
 
-**Decision:** `Ctrl+,` settings menu is backed by a pure descriptor layer
-(`src/settings.rs`) with **no dependency on `App`**, plus a projection to/from
-`App` state.
+**Decision:** `Ctrl+,` settings menu is backed by a descriptor registry
+(`src/settings.rs::descriptors()`) that is the single source of truth for what
+settings exist and how they behave. There is no separate `SettingsModel`
+snapshot and no `settings_model()`/`apply_settings_model()` projection — each
+descriptor carries fn-pointer accessors that read and write the live value
+**directly on `App`**, and a persistence lens, so the menu and the store share
+one definition.
 
-**Why:** Keeping the registry pure makes menu logic (cycling values, clamping
-ints, display formatting) unit-testable without a TUI or an `App`, and gives
-the widget and the action handler a single shared source of truth for what
-settings exist and how they behave.
+**Why:** One entry per setting means no hand-written projection to drift out of
+sync. The pure value operations (`cycle_value`, `clamp_int`, `format_value`,
+`filter_descriptors`) take no `App`, so the menu logic (cycling, clamping,
+display, fuzzy filtering) stays unit-testable without a TUI.
 
 **How it works:**
-- `SettingsModel` — a flat, plain-data snapshot of every editable setting.
-- `SettingDescriptor` — one menu row: a `SettingKind` (`Bool` / `Enum{options}`
-  / `Int{min,max,step,zero_label}`), typed get/set accessors, display logic,
-  grouped under a `SettingGroup` (Graph/Files/Refresh/Interface, in menu
-  order), and its persistence destination.
-- `App::settings_model()` gathers scattered `App` fields (trace state, metadata
-  columns, `config.ui`, etc.) into a `SettingsModel`; `App::apply_settings_model()`
-  writes an edited model back, including clamping (e.g. split ratio to 20-80)
-  and sentinel handling (e.g. `0` → `None` for an uncapped width).
-- **Persistence is split by destination.** State-only settings (e.g. UI
-  toggles that aren't meant to be hand-edited) go through `UiState::save()` to
-  `state.toml`, plain serde round-trip. Config-file settings go through
+- `SettingDescriptor` — one menu row: a `label`, a `SettingGroup`
+  (Graph/Files/Refresh/Interface, in menu order), a `SettingKind` (`Bool` /
+  `Enum{options}` / `Int{min,max,step,zero_label}`), an optional `note` (e.g.
+  "restart"), a `SettingStore` (persistence destination), and `get`/`set`
+  fn-pointers onto `App`. Descriptors are built by the `state_bool!` /
+  `config_bool!` / `config_int!` macros so the common shapes are declared in a
+  single line.
+- **Persistence lives in the descriptor.** `SettingStore::State { read, write }`
+  carries the lens between the `SettingValue` and its `UiState` field, so
+  state-persisted settings save to `state.toml` via `App::save_ui_state`
+  (a loop over the descriptors, `UiState::save()` underneath). `SettingStore::Config`
+  settings write `app.config.*` through the `set` accessor and persist via
   `Config::save()` (`src/config.rs`) using **`toml_edit`**, which rewrites only
   the touched keys in the existing document (`doc["refresh"]["auto_refresh"] =
-  value(...)`) rather than re-serializing the whole file — so comments and keys
-  the menu doesn't know about survive a save.
+  value(...)`) rather than re-serializing — so comments and keys the menu
+  doesn't know about survive a save. `App::settings_snapshot` is the read-side
+  loop.
+- **Clamping / sentinels are in the kind, not a projection.** `clamp_int`
+  bounds an `Int` to its `min`/`max` (e.g. graph split ratio 20-80); a
+  `zero_label` (e.g. "uncapped" for the graph width cap) shows a friendly token
+  in place of `0`, encoded once via the `cap_to_value`/`value_to_cap` helpers.
 - `graph_renderer` is **restart-only**: its descriptor carries a `note:
   Some("restart")` shown in the menu, because `PixelGraphState` (terminal
   graphics-protocol detection) is constructed once in `main.rs` before the
@@ -303,7 +312,7 @@ settings exist and how they behave.
 
 **Decision:** Whether a branch is merged is a pure domain computation
 (`src/git/merged.rs`), fed by async GitHub polling infrastructure
-(`src/merged_branches.rs`) that never blocks a frame.
+(`src/merged_branch_fetch.rs`) that never blocks a frame.
 
 **Domain logic** (`src/git/merged.rs`):
 - `is_ancestor_merged()` — the cheap case: `graph_descendant_of(base_tip,
@@ -402,13 +411,39 @@ from …"` merge-commit message (distinguishing it from a local `"Merge
 branch …"`) — covers PRs that are already closed by the time of render, so
 have no open-PR index entry.
 
+## Graph View Widget Modules
+
+**Decision:** The graph-row widget is the `src/ui/graph_view/` package (was one
+`graph_view.rs`), split by responsibility with typed seams between the passes so
+each is independently testable and the render tail carries no ad-hoc tuples:
+
+- `mod.rs` — widget entry / glue (`render_graph_line`, list-item assembly).
+- `metrics.rs` — text metrics: VS16-aware display width, width-bounded
+  truncation, compact relative-date formatting.
+- `geometry.rs` — graph-column geometry: `GRAPH_LEADING_COLUMNS`, avatar
+  reservations, effective width / cap arithmetic, the per-row truncation budget
+  shared by the unicode and pixel renderers.
+- `rows.rs` — row folding + viewport windowing (`RenderRow`,
+  `visible_row_window`).
+- `chips.rs` — branch-chip construction. `optimize_branch_display` yields typed
+  `BranchChip`s, each carrying the real click-target ref from construction (so
+  the hit-test isn't re-derived at render time).
+- `badges.rs` — pure PR/merged badge decisions; `pr_for_row` returns a typed
+  `PrBadge` the render tail draws directly.
+- `pixel_dim.rs` — pixel base-spec build (`build_pixel_base_specs`) + per-frame
+  dim windowing (`dim_pixel_specs_window`, `apply_trace_dim`).
+- `row.rs` — the message tail as a pure decision pass (`resolve_row_model` →
+  `RowModel` of styling/label/message *decisions*, no widths or spans) followed
+  by a layout pass (`layout_row`) that turns the model into the final `Line` +
+  `ChipHit`s.
+
 ## Windowed Rendering (2026-07-20)
 
 **Decision:** Both the text (Unicode) graph and the pixel-graph path avoid
 rebuilding every row on every keypress; only the visible window is rebuilt,
 and pixel caching goes further by never invalidating on trace state.
 
-**Text layer:** `visible_row_window()` (`src/ui/graph_view.rs`) computes which
+**Text layer:** `visible_row_window()` (`src/ui/graph_view/rows.rs`) computes which
 row indices actually need styled `ListItem`s built — the viewport plus an
 8-row margin, always including the selected row. Everything outside the
 window gets a cheap blank placeholder so the list's length (and therefore


### PR DESCRIPTION
Full rewrite of CLAUDE.md, 74 → 30 lines. Removed everything a capable agent derives from the code in seconds: the cargo command table, key-binding lists, the AppMode enum inventory, and the module-by-module tour.

What stays, and why:
- **Workflow** — the issue → branch → PR → squash protocol (now the enforced path), TODO.md retired to a historical log (its numbering double-booked across parallel sessions), and the requirement to verify TUI-visible changes in the real app via the debug server.
- **Architecture** — one paragraph on the event-loop shape with a pointer to docs/architecture.md.
- **Load-bearing decisions** — only the constraints whose *why* is invisible in code and whose violation has bitten before: focus⊥mode, errors-as-toasts/no blocking modal, the two-tier diff cache's deliberate latching and anti-flash behavior, the pure settings registry, the intentionally-parallel unicode/pixel dim paths, and the no-clipboard-crate rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EzeThF8q4rK6CcqYEVscqD