### PR TITLE
fix(git): classify base-update merges against the PR's own base branch

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1608,31 +1608,46 @@ impl App {
     }
 
     /// Recompute the set of base-update ("back-merge") commits (issue #55) from
-    /// the current open PRs and base branch, storing it in `base_update_merges`.
-    /// Cheap (bounded per-PR walks on the UI thread's repo handle) and guarded by
-    /// an input signature so a frequent refresh does no work when neither the
-    /// base tip nor the open-PR head set has changed. Safe to call every refresh
+    /// the current open PRs, storing it in `base_update_merges`. Each PR is
+    /// tested against the tips of **its own base branch** (`baseRefName`, #103)
+    /// — a PR targeting `dev` back-merges `dev`, which the repo-wide trunk does
+    /// not contain; that trunk remains only the fallback for PRs whose base gh
+    /// didn't report. Cheap (bounded per-pair walks on the UI thread's repo
+    /// handle) and guarded by an input signature so a frequent refresh does no
+    /// work when no head or base tip has changed. Safe to call every refresh
     /// and whenever `open_prs` updates; the render path only *reads* the set.
     pub(crate) fn recompute_base_update_merges(&mut self) {
-        let Some(base) = crate::git::merged::base_branch(&self.branches) else {
+        let fallback = crate::git::merged::base_branch(&self.branches).map(|b| b.tip_oid);
+        let mut pairs: Vec<(git2::Oid, git2::Oid)> = self
+            .open_prs
+            .values()
+            .filter_map(|p| p.head_oid().map(|head| (head, p)))
+            .flat_map(|(head, p)| {
+                let tips = match p.base_ref.as_deref() {
+                    Some(base) => crate::git::merged::base_ref_tips(&self.branches, base),
+                    None => Vec::new(),
+                };
+                // An unresolvable base (not fetched locally) degrades to the
+                // repo-wide trunk — same result as before #103, never worse.
+                let tips = if tips.is_empty() {
+                    fallback.into_iter().collect()
+                } else {
+                    tips
+                };
+                tips.into_iter().map(move |tip| (head, tip))
+            })
+            .collect();
+        // Sorted so the signature is order-independent.
+        pairs.sort();
+        pairs.dedup();
+        if pairs.is_empty() {
             self.merged.base_update.reset(std::collections::HashSet::new());
             return;
-        };
-        // Sorted PR head OIDs so the signature is order-independent.
-        let mut pr_heads: Vec<git2::Oid> =
-            self.open_prs.values().filter_map(|p| p.head_oid()).collect();
-        pr_heads.sort();
-        // Signature: base tip + the (sorted) head set. Unchanged ⇒ result is
-        // identical, so the guard skips the ancestry walks below.
+        }
         let repo = self.repo.repo();
-        self.merged.base_update
-            .recompute_if_changed((base.tip_oid, &pr_heads), || {
-                if pr_heads.is_empty() {
-                    std::collections::HashSet::new()
-                } else {
-                    crate::git::merged::classify_base_update_merges(repo, &pr_heads, base.tip_oid)
-                }
-            });
+        self.merged.base_update.recompute_if_changed(&pairs, || {
+            crate::git::merged::classify_base_update_merges(repo, &pairs)
+        });
     }
 
     /// Toggle soft line-wrapping in the file-diff viewer (persisted). The next

--- a/src/git/merged.rs
+++ b/src/git/merged.rs
@@ -656,6 +656,32 @@ pub fn merged_local_branches(
 /// practice; this window is generous.
 const BASE_UPDATE_SCAN_LIMIT: usize = 400;
 
+/// Every locally-known tip of the branch named `base_ref` (a PR's `baseRefName`,
+/// always unqualified): the local branch of that name plus each remote's
+/// `<remote>/<base_ref>`. All tips are returned rather than picking one because
+/// local and remote may disagree (unpushed / unfetched base commits) and a
+/// back-merge's second parent need only be reachable from *some* tip of the
+/// base — testing each costs one bounded walk per tip.
+pub fn base_ref_tips(branches: &[BranchInfo], base_ref: &str) -> Vec<Oid> {
+    let mut tips: Vec<Oid> = branches
+        .iter()
+        .filter(|b| {
+            if b.is_remote {
+                // "<remote>/<branch>": the segment after the remote must equal
+                // the base name exactly — `ends_with` would also claim
+                // `origin/feature/dev` for base `dev`.
+                b.name.split_once('/').is_some_and(|(_, rest)| rest == base_ref)
+            } else {
+                b.name == base_ref
+            }
+        })
+        .map(|b| b.tip_oid)
+        .collect();
+    tips.sort();
+    tips.dedup();
+    tips
+}
+
 /// Classify **base-update ("back-merge") commits**: merge commits that sit on an
 /// open PR's branch — reachable from the PR head but *not yet on the base* — and
 /// whose **second parent** is on the base branch. That is exactly the shape of
@@ -670,17 +696,20 @@ const BASE_UPDATE_SCAN_LIMIT: usize = 400;
 /// filter (`revwalk.hide(base_tip)`) drops it before the second-parent test ever
 /// runs. Direction is thus decided structurally, not by message text.
 ///
-/// Pure over a `git2::Repository`; `pr_heads` are the open PRs' head-commit OIDs
-/// (from `PrInfo::head_oid`). Cheap: for each PR it walks only that branch's own
-/// commits (the revwalk hides `base_tip`), bounded by [`BASE_UPDATE_SCAN_LIMIT`],
-/// with one ancestry query per merge encountered.
+/// Pure over a `git2::Repository`; each pair is an open PR's head-commit OID
+/// (from `PrInfo::head_oid`) with the tip of **that PR's own base branch** — a
+/// PR targeting `dev` back-merges `dev`, and testing its merges against the
+/// repo-wide trunk instead silently matched nothing (#103). A head may appear
+/// in several pairs (one per locally-known tip of its base). Cheap: for each
+/// pair it walks only that branch's own commits (the revwalk hides `base_tip`),
+/// bounded by [`BASE_UPDATE_SCAN_LIMIT`], with one ancestry query per merge
+/// encountered.
 pub fn classify_base_update_merges(
     repo: &Repository,
-    pr_heads: &[Oid],
-    base_tip: Oid,
+    head_base_pairs: &[(Oid, Oid)],
 ) -> HashSet<Oid> {
     let mut out = HashSet::new();
-    for &head in pr_heads {
+    for &(head, base_tip) in head_base_pairs {
         // Commits reachable from the PR head but NOT already on the base: the
         // PR branch's own commits. A landing merge is on the base, so hiding
         // `base_tip` removes it here — only still-ahead back-merges survive.
@@ -1750,7 +1779,7 @@ mod tests {
             &[f, c],
             &[("base.txt", "base2"), ("feat.txt", "x")],
         );
-        let set = classify_base_update_merges(&repo, &[m], c);
+        let set = classify_base_update_merges(&repo, &[(m, c)]);
         assert!(set.contains(&m), "the back-merge commit is classified");
         assert_eq!(set.len(), 1);
     }
@@ -1775,7 +1804,7 @@ mod tests {
             &[("base.txt", "base"), ("main.txt", "m"), ("feat.txt", "x")],
         );
         // Base tip is the landing merge itself.
-        let set = classify_base_update_merges(&repo, &[t], m);
+        let set = classify_base_update_merges(&repo, &[(t, m)]);
         assert!(set.is_empty(), "a PR-landing merge is never a back-merge");
     }
 
@@ -1800,7 +1829,7 @@ mod tests {
             &[f, s],
             &[("base.txt", "base"), ("f.txt", "f"), ("s.txt", "s")],
         );
-        let set = classify_base_update_merges(&repo, &[m], c);
+        let set = classify_base_update_merges(&repo, &[(m, c)]);
         assert!(set.is_empty(), "merging a non-base sibling is not a base-update");
     }
 
@@ -1811,9 +1840,9 @@ mod tests {
         let a = commit(&repo, "refs/heads/main", 1000, &[], &[("base.txt", "base")]);
         let f = commit(&repo, "refs/heads/feature", 1500, &[a], &[("base.txt", "base"), ("x.txt", "x")]);
         // No PR heads at all.
-        assert!(classify_base_update_merges(&repo, &[], a).is_empty());
+        assert!(classify_base_update_merges(&repo, &[]).is_empty());
         // A PR head whose branch has no merge commit.
-        assert!(classify_base_update_merges(&repo, &[f], a).is_empty());
+        assert!(classify_base_update_merges(&repo, &[(f, a)]).is_empty());
     }
 
     #[test]
@@ -1833,7 +1862,74 @@ mod tests {
             &[("base.txt", "base2"), ("feat.txt", "x")],
         );
         let g = commit(&repo, "refs/heads/feature", 3500, &[m], &[("base.txt", "base2"), ("feat.txt", "y")]);
-        let set = classify_base_update_merges(&repo, &[g], c);
+        let set = classify_base_update_merges(&repo, &[(g, c)]);
         assert!(set.contains(&m), "a mid-branch back-merge is still found");
+    }
+
+    #[test]
+    fn back_merge_classifies_against_the_prs_own_base_not_the_trunk() {
+        // The #103 shape: the repo's trunk is `main`, but the PR targets `dev`.
+        // main: a
+        // dev:  a <- d1 <- d2
+        // feature (off dev): d1 <- f, then back-merge m = [f, d2].
+        let dir = tempfile::tempdir().unwrap();
+        let repo = Repository::init(dir.path()).unwrap();
+        let a = commit(&repo, "refs/heads/main", 1000, &[], &[("base.txt", "base")]);
+        let d1 = commit(&repo, "refs/heads/dev", 1500, &[a], &[("base.txt", "base"), ("d.txt", "1")]);
+        let f = commit(&repo, "refs/heads/feature", 2000, &[d1], &[("base.txt", "base"), ("d.txt", "1"), ("f.txt", "f")]);
+        let d2 = commit(&repo, "refs/heads/dev", 2500, &[d1], &[("base.txt", "base"), ("d.txt", "2")]);
+        let m = commit(
+            &repo,
+            "refs/heads/feature",
+            3000,
+            &[f, d2],
+            &[("base.txt", "base"), ("d.txt", "2"), ("f.txt", "f")],
+        );
+        // Paired with the PR's real base (dev), the back-merge is found.
+        let set = classify_base_update_merges(&repo, &[(m, d2)]);
+        assert!(set.contains(&m), "dev back-merge classifies against dev's tip");
+        // Paired with the repo-wide trunk (the pre-#103 behavior), it is
+        // invisible: m's second parent is on dev, not on main.
+        assert!(
+            classify_base_update_merges(&repo, &[(m, a)]).is_empty(),
+            "the trunk pairing cannot see a dev back-merge — the old bug"
+        );
+    }
+
+    // ── base_ref_tips: resolving a PR's baseRefName locally (#103) ───
+
+    #[test]
+    fn base_ref_tips_collects_local_and_every_remote_mirror() {
+        let o = |n: u32| Oid::from_str(&format!("{n:040x}")).unwrap();
+        let branches = vec![
+            local("dev", o(1), false),
+            remote("origin/dev", o(2)),
+            remote("upstream/dev", o(3)),
+            local("main", o(4), true),
+            remote("origin/main", o(5)),
+        ];
+        let tips = base_ref_tips(&branches, "dev");
+        assert_eq!(tips, vec![o(1), o(2), o(3)]);
+    }
+
+    #[test]
+    fn base_ref_tips_requires_an_exact_branch_segment_match() {
+        let o = |n: u32| Oid::from_str(&format!("{n:040x}")).unwrap();
+        // `origin/feature/dev` is the branch `feature/dev`, not `dev` — a
+        // suffix match would wrongly claim it.
+        let branches = vec![
+            remote("origin/feature/dev", o(1)),
+            local("feature/dev", o(2), false),
+        ];
+        assert!(base_ref_tips(&branches, "dev").is_empty());
+        assert_eq!(base_ref_tips(&branches, "feature/dev"), vec![o(1), o(2)]);
+    }
+
+    #[test]
+    fn base_ref_tips_dedups_agreeing_local_and_remote() {
+        let o = |n: u32| Oid::from_str(&format!("{n:040x}")).unwrap();
+        let branches = vec![local("dev", o(7), false), remote("origin/dev", o(7))];
+        assert_eq!(base_ref_tips(&branches, "dev"), vec![o(7)]);
+        assert!(base_ref_tips(&[], "dev").is_empty());
     }
 }

--- a/src/pr.rs
+++ b/src/pr.rs
@@ -104,6 +104,12 @@ pub struct PrInfo {
     /// `None` when `gh` didn't report it (older CLI / malformed record); the
     /// renderer then falls back to head-branch-name matching.
     pub head_oid: Option<String>,
+    /// The branch the PR is opened against (`baseRefName`). Base-update-merge
+    /// classification (issue #55) must test against *this* branch's tip — a PR
+    /// targeting `dev` back-merges `dev`, which the repo-wide trunk (`main`)
+    /// does not contain (#103). `None` when `gh` didn't report it; classification
+    /// then falls back to the repo-wide base branch.
+    pub base_ref: Option<String>,
 }
 
 impl PrInfo {
@@ -165,6 +171,8 @@ struct GhPr {
     head_ref_name: String,
     #[serde(default, rename = "headRefOid")]
     head_ref_oid: Option<String>,
+    #[serde(default, rename = "baseRefName")]
+    base_ref_name: Option<String>,
     #[serde(default)]
     title: String,
     #[serde(default)]
@@ -282,6 +290,7 @@ pub fn parse_pr_list(json: &str) -> HashMap<String, PrInfo> {
                     merge_state,
                     outside_activity,
                     head_oid: p.head_ref_oid.filter(|s| !s.is_empty()),
+                    base_ref: p.base_ref_name.filter(|s| !s.is_empty()),
                 },
             )
         })
@@ -497,7 +506,7 @@ fn fetch_open_prs(repo_path: &str) -> Result<HashMap<String, PrInfo>, String> {
             "pr",
             "list",
             "--json",
-            "number,url,headRefName,headRefOid,title,state,statusCheckRollup,reviewDecision,mergeStateStatus,comments,reviews,author",
+            "number,url,headRefName,headRefOid,baseRefName,title,state,statusCheckRollup,reviewDecision,mergeStateStatus,comments,reviews,author",
             "--limit",
             "100",
         ],
@@ -536,6 +545,7 @@ mod tests {
                 merge_state: MergeState::Clear,
                 outside_activity: false,
                 head_oid: None,
+                base_ref: None,
             })
         );
         assert_eq!(map.get("fix/y").map(|p| p.number), Some(7));
@@ -772,6 +782,16 @@ mod tests {
     }
 
     #[test]
+    fn base_ref_parsed_from_json() {
+        // #103: the PR's own base branch, so back-merge classification can
+        // anchor on it instead of the repo-wide trunk.
+        assert_eq!(one(r#","baseRefName":"dev""#).base_ref.as_deref(), Some("dev"));
+        assert_eq!(one("").base_ref, None);
+        assert_eq!(one(r#","baseRefName":"""#).base_ref, None);
+        assert_eq!(one(r#","baseRefName":null"#).base_ref, None);
+    }
+
+    #[test]
     fn head_oid_absent_or_empty_is_none() {
         assert_eq!(one("").head_oid, None);
         assert_eq!(one(r#","headRefOid":"""#).head_oid, None);
@@ -792,6 +812,7 @@ mod tests {
             merge_state: MergeState::Clear,
             outside_activity: false,
             head_oid: head.map(str::to_string),
+            base_ref: None,
         }
     }
 
@@ -874,6 +895,7 @@ mod tests {
             merge_state: MergeState::Clear,
             outside_activity: false,
             head_oid: None,
+            base_ref: None,
         }
     }
 

--- a/src/pr_action.rs
+++ b/src/pr_action.rs
@@ -401,6 +401,7 @@ mod tests {
             merge_state: crate::pr::MergeState::Clear,
             outside_activity: false,
             head_oid: None,
+            base_ref: None,
         }
     }
 

--- a/src/ui/graph_view/badges.rs
+++ b/src/ui/graph_view/badges.rs
@@ -158,6 +158,7 @@ mod tests {
             merge_state: MergeState::Clear,
             outside_activity: false,
             head_oid: None,
+            base_ref: None,
         }
     }
 
@@ -181,6 +182,7 @@ mod tests {
             merge_state,
             outside_activity: outside,
             head_oid: None,
+            base_ref: None,
         }
     }
 

--- a/src/ui/graph_view/mod.rs
+++ b/src/ui/graph_view/mod.rs
@@ -564,6 +564,7 @@ mod tests {
             merge_state: MergeState::Clear,
             outside_activity: false,
             head_oid: None,
+            base_ref: None,
         }
     }
 


### PR DESCRIPTION
The "mute base update merges" setting (issue #55) classified back-merges by testing each merge's second parent against the **repo-wide trunk** (`base_branch()`, main/master priority). But the feature's defining scenario — a PR opened against `dev` that gets `dev` merged into it — back-merges `dev`, whose tip is not on `main`'s first-parent history. Result: the mute never fired precisely where it was meant to.

- `PrInfo` now carries `base_ref` (`baseRefName`, added to the `gh pr list --json` field set).
- `classify_base_update_merges` takes `(head, base_tip)` pairs instead of a global base tip.
- `recompute_base_update_merges` pairs each PR head with every locally-known tip of its base (`base_ref_tips`: local branch + each remote's mirror, exact segment match so `origin/feature/dev` can't claim base `dev`) — local and remote may disagree, and the back-merge's second parent need only be reachable from one of them. The repo-wide trunk remains the fallback for PRs whose base gh didn't report (older CLI), so behavior is never worse than before.
- Signature guard now keys on the sorted pair set.

Tests: the #103 shape (trunk `main` present, PR against `dev`) classifies against `dev` and provably not against `main`; `base_ref_tips` local/remote collection, exact-segment matching, dedup; `baseRefName` JSON parsing. Render path (`is_base_update_row`) is untouched, so no TUI-visible change beyond the mute finally firing; verified via unit tests.

Closes #103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)