### PR TITLE
feat(input): toast a hint when CapsLock appears to be on

### DIFF
--- a/src/app/init.rs
+++ b/src/app/init.rs
@@ -284,6 +284,7 @@ impl App {
             metadata_columns: ui_state.metadata_columns,
             graph_width_cap: ui_state.graph_width_cap,
             debug_keys: false,
+            last_capslock_hint: None,
             perf,
             mouse_layout: MouseLayout::default(),
             last_click: None,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1126,6 +1126,10 @@ pub struct App {
     // Debug mode
     pub debug_keys: bool,
 
+    /// When the CapsLock hint toast last fired (#106), for rate-limiting —
+    /// not persisted, purely a within-session cooldown.
+    pub last_capslock_hint: Option<std::time::Instant>,
+
     // Performance counters. Recorded on the render/refresh paths; a summary is
     // logged on exit (only visible with --log-file).
     pub perf: crate::perf::PerfStats,

--- a/src/app/status_message.rs
+++ b/src/app/status_message.rs
@@ -6,6 +6,11 @@ use std::time::{Duration, Instant};
 /// How long a transient status message stays on screen before it clears.
 const MESSAGE_TIMEOUT: Duration = Duration::from_secs(5);
 
+/// Minimum spacing between CapsLock hint toasts (#106). Without this, holding
+/// a caps-locked key (or just navigating with it on) would spawn a fresh toast
+/// on every keystroke.
+const CAPSLOCK_HINT_COOLDOWN: Duration = Duration::from_secs(30);
+
 /// Pure visibility rule for a status message, so the timeout/stickiness logic is
 /// unit-testable without a clock or a live network op.
 ///
@@ -89,6 +94,38 @@ impl App {
         self.toasts.push(kind, text, std::time::Instant::now());
     }
 
+    /// Nudge the user when a keystroke looks like it was typed with CapsLock on
+    /// (#106) — case-sensitive keybindings otherwise fail silently. No-ops
+    /// while the key was consumed as free text (commit editor, Input mode,
+    /// filters, compose editors, command palette, settings query): uppercase
+    /// is expected there, not a sign of a broken binding. Rate-limited via
+    /// `last_capslock_hint` so a held or repeated key doesn't spam a toast.
+    pub fn maybe_hint_capslock(&mut self, key: &crossterm::event::KeyEvent) {
+        if !crate::keybindings::looks_like_capslock(key) {
+            return;
+        }
+        if crate::keybindings::is_text_editing_context(
+            &self.mode,
+            self.focused_panel,
+            self.editing_commit_message,
+            self.files_pane.files_filter_active,
+            self.commit_filter_active,
+        ) {
+            return;
+        }
+        let now = Instant::now();
+        if let Some(last) = self.last_capslock_hint {
+            if now.duration_since(last) < CAPSLOCK_HINT_COOLDOWN {
+                return;
+            }
+        }
+        self.last_capslock_hint = Some(now);
+        self.toast(
+            crate::toast::ToastKind::Info,
+            "CapsLock appears to be on — keys are case-sensitive",
+        );
+    }
+
     /// The next instant a toast or the status message will need a redraw.
     pub fn next_render_deadline(&self) -> Option<std::time::Instant> {
         [self.message_expiry_time(), self.toasts.next_expiry()]
@@ -134,5 +171,89 @@ mod tests {
     fn sticky_message_clears_once_op_no_longer_busy() {
         let expired = MESSAGE_TIMEOUT + Duration::from_secs(1);
         assert!(!message_visible(expired, true, false));
+    }
+}
+
+#[cfg(test)]
+mod capslock_hint_tests {
+    use crate::app::App;
+    use crate::git::repository::GitRepository;
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    fn test_app() -> (tempfile::TempDir, App) {
+        let tempdir = tempfile::tempdir().unwrap();
+        git2::Repository::init(tempdir.path()).unwrap();
+        let repo = GitRepository::open(tempdir.path()).unwrap();
+        let app = App::from_repo(repo).unwrap();
+        (tempdir, app)
+    }
+
+    fn capslock_key() -> KeyEvent {
+        KeyEvent::new(KeyCode::Char('K'), KeyModifiers::NONE)
+    }
+
+    #[test]
+    fn capslock_signature_key_in_normal_mode_toasts() {
+        let (_tmp, mut app) = test_app();
+        assert!(app.toasts.is_empty());
+        app.maybe_hint_capslock(&capslock_key());
+        assert_eq!(app.toasts.visible().len(), 1);
+        assert_eq!(app.toasts.visible()[0].kind, crate::toast::ToastKind::Info);
+    }
+
+    #[test]
+    fn no_toast_while_editing_commit_message() {
+        let (_tmp, mut app) = test_app();
+        app.focused_panel = crate::app::FocusedPanel::CommitDetail;
+        app.editing_commit_message = true;
+        app.maybe_hint_capslock(&capslock_key());
+        assert!(
+            app.toasts.is_empty(),
+            "typing uppercase in the commit editor is normal, not a CapsLock signal"
+        );
+    }
+
+    #[test]
+    fn no_toast_while_a_text_filter_is_active() {
+        let (_tmp, mut app) = test_app();
+        app.focused_panel = crate::app::FocusedPanel::Files;
+        app.files_pane.files_filter_active = true;
+        app.maybe_hint_capslock(&capslock_key());
+        assert!(app.toasts.is_empty());
+    }
+
+    #[test]
+    fn no_toast_while_input_mode_is_capturing_text() {
+        let (_tmp, mut app) = test_app();
+        app.mode = crate::app::AppMode::Input {
+            title: "Branch name".into(),
+            input: String::new(),
+            action: crate::app::InputAction::CreateBranch,
+        };
+        app.maybe_hint_capslock(&capslock_key());
+        assert!(app.toasts.is_empty());
+    }
+
+    #[test]
+    fn second_capslock_key_within_cooldown_does_not_toast_again() {
+        let (_tmp, mut app) = test_app();
+        app.maybe_hint_capslock(&capslock_key());
+        assert_eq!(app.toasts.visible().len(), 1);
+        // Immediately repeated (well within the 30s cooldown): must not add
+        // a second toast.
+        app.maybe_hint_capslock(&capslock_key());
+        assert_eq!(
+            app.toasts.visible().len(),
+            1,
+            "rate limit must suppress a second hint within the cooldown"
+        );
+    }
+
+    #[test]
+    fn genuine_shift_uppercase_never_toasts() {
+        let (_tmp, mut app) = test_app();
+        let shifted = KeyEvent::new(KeyCode::Char('K'), KeyModifiers::SHIFT);
+        app.maybe_hint_capslock(&shifted);
+        assert!(app.toasts.is_empty());
     }
 }

--- a/src/debug_server.rs
+++ b/src/debug_server.rs
@@ -115,6 +115,7 @@ pub fn handle_request(app: &mut App, width: u16, height: u16, request: DebugRequ
         DebugRequest::Keys { keys } => match parse_key_sequence(&keys) {
             Ok(events) => {
                 for key in events {
+                    app.maybe_hint_capslock(&key);
                     if let Some(action) = map_key_to_action(
                         key,
                         &app.mode,

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -103,6 +103,55 @@ pub fn map_key_to_action(
     }
 }
 
+/// True when a keystroke matches the CapsLock signature: an uppercase letter
+/// arriving WITHOUT the SHIFT modifier (#106). With the keyboard-enhancement
+/// flags active (`DISAMBIGUATE_ESCAPE_CODES`, see `tui::init`) a genuine
+/// Shift+letter always carries the SHIFT modifier, so it never matches here —
+/// only CapsLock (or a terminal reporting caps state as the bare letter)
+/// produces an uppercase char with no modifier. On legacy terminals that infer
+/// SHIFT from the uppercase byte itself, this simply never fires; that silent
+/// degradation is acceptable, not a case to special-case around.
+pub fn looks_like_capslock(key: &KeyEvent) -> bool {
+    if key.kind == KeyEventKind::Release {
+        return false;
+    }
+    match key.code {
+        KeyCode::Char(c) => c.is_uppercase() && !key.modifiers.contains(KeyModifiers::SHIFT),
+        _ => false,
+    }
+}
+
+/// Whether the current mode/flags route character keys into a free-text
+/// buffer rather than single-key commands — the commit-message editor, Input
+/// mode (branch/tag/search), the graph/files text filters, PR/issue compose,
+/// the command palette, and the settings query. Mirrors the same
+/// mode/flag checks `map_key_to_action` uses to route into those handlers, so
+/// callers that only need "is the user typing text right now" (e.g. the
+/// CapsLock hint, which must never fire on legitimate uppercase text) don't
+/// have to run a key through the full dispatcher to find out.
+pub fn is_text_editing_context(
+    mode: &AppMode,
+    panel: FocusedPanel,
+    editing_commit: bool,
+    files_filter_active: bool,
+    commit_filter_active: bool,
+) -> bool {
+    match mode {
+        AppMode::Normal => {
+            (editing_commit && panel == FocusedPanel::CommitDetail)
+                || (panel == FocusedPanel::Graph && commit_filter_active)
+                || (panel == FocusedPanel::Files && files_filter_active)
+        }
+        AppMode::Input { .. }
+        | AppMode::PrCompose { .. }
+        | AppMode::IssueCompose { .. }
+        | AppMode::BranchFilter { .. }
+        | AppMode::CommandPalette { .. }
+        | AppMode::Settings { .. } => true,
+        _ => false,
+    }
+}
+
 /// Command palette: type to filter, ↑↓ to navigate, Enter to run, Esc to close.
 /// Reuses the shared single-line text-editing shortcuts for the query.
 fn map_command_palette_mode(key: KeyEvent) -> Option<Action> {
@@ -1178,5 +1227,149 @@ mod tests {
             map_confirm_mode(r),
             Some(Action::ConfirmDeleteBranchAndRemote)
         );
+    }
+
+    #[test]
+    fn capslock_signature_is_uppercase_letter_without_shift() {
+        let key = KeyEvent::new(KeyCode::Char('K'), KeyModifiers::NONE);
+        assert!(looks_like_capslock(&key));
+    }
+
+    #[test]
+    fn genuine_shift_uppercase_is_not_capslock() {
+        let key = KeyEvent::new(KeyCode::Char('K'), KeyModifiers::SHIFT);
+        assert!(!looks_like_capslock(&key));
+    }
+
+    #[test]
+    fn lowercase_is_never_capslock() {
+        let key = KeyEvent::new(KeyCode::Char('k'), KeyModifiers::NONE);
+        assert!(!looks_like_capslock(&key));
+    }
+
+    #[test]
+    fn non_alphabetic_chars_are_never_capslock() {
+        // '?' and ':' arrive shifted on most layouts but aren't letters, so
+        // `is_uppercase()` is false for them regardless of the modifier.
+        let question = KeyEvent::new(KeyCode::Char('?'), KeyModifiers::NONE);
+        let colon = KeyEvent::new(KeyCode::Char(':'), KeyModifiers::SHIFT);
+        assert!(!looks_like_capslock(&question));
+        assert!(!looks_like_capslock(&colon));
+    }
+
+    #[test]
+    fn release_events_are_never_capslock() {
+        let key = KeyEvent::new_with_kind(
+            KeyCode::Char('K'),
+            KeyModifiers::NONE,
+            KeyEventKind::Release,
+        );
+        assert!(!looks_like_capslock(&key));
+    }
+
+    #[test]
+    fn repeat_events_can_be_capslock() {
+        // A held caps-locked key repeats; the hint should still be eligible.
+        let key = KeyEvent::new_with_kind(
+            KeyCode::Char('K'),
+            KeyModifiers::NONE,
+            KeyEventKind::Repeat,
+        );
+        assert!(looks_like_capslock(&key));
+    }
+
+    #[test]
+    fn non_char_keys_are_never_capslock() {
+        let key = KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE);
+        assert!(!looks_like_capslock(&key));
+    }
+
+    #[test]
+    fn commit_editor_is_a_text_editing_context() {
+        assert!(is_text_editing_context(
+            &AppMode::Normal,
+            FocusedPanel::CommitDetail,
+            true,
+            false,
+            false,
+        ));
+        // Editing flag only applies while focus is actually on CommitDetail.
+        assert!(!is_text_editing_context(
+            &AppMode::Normal,
+            FocusedPanel::Graph,
+            true,
+            false,
+            false,
+        ));
+    }
+
+    #[test]
+    fn active_filters_are_text_editing_contexts() {
+        assert!(is_text_editing_context(
+            &AppMode::Normal,
+            FocusedPanel::Graph,
+            false,
+            false,
+            true,
+        ));
+        assert!(is_text_editing_context(
+            &AppMode::Normal,
+            FocusedPanel::Files,
+            false,
+            true,
+            false,
+        ));
+    }
+
+    #[test]
+    fn text_capturing_modes_are_editing_contexts() {
+        let input = AppMode::Input {
+            title: String::new(),
+            input: String::new(),
+            action: crate::app::InputAction::CreateBranch,
+        };
+        let palette = AppMode::CommandPalette {
+            query: String::new(),
+            selected: 0,
+        };
+        assert!(is_text_editing_context(
+            &input,
+            FocusedPanel::Graph,
+            false,
+            false,
+            false
+        ));
+        assert!(is_text_editing_context(
+            &palette,
+            FocusedPanel::Graph,
+            false,
+            false,
+            false
+        ));
+    }
+
+    #[test]
+    fn plain_navigation_modes_are_not_editing_contexts() {
+        assert!(!is_text_editing_context(
+            &AppMode::Normal,
+            FocusedPanel::Graph,
+            false,
+            false,
+            false,
+        ));
+        assert!(!is_text_editing_context(
+            &AppMode::Help,
+            FocusedPanel::Graph,
+            false,
+            false,
+            false,
+        ));
+        assert!(!is_text_editing_context(
+            &AppMode::CiChecks,
+            FocusedPanel::Graph,
+            false,
+            false,
+            false,
+        ));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,6 +107,7 @@ fn handle_input_event(
                 key.code, key.modifiers
             ));
         }
+        app.maybe_hint_capslock(&key);
         if let Some(action) = map_key_to_action(
             key,
             &app.mode,


### PR DESCRIPTION
## Summary

When CapsLock is on, keybindings are case-sensitive and silently don't match — the user has no idea why nothing responds. This shows a one-shot Info toast the first time a keystroke matches the CapsLock signature.

## Detection

`looks_like_capslock` (`src/keybindings.rs`) is a pure function: a `KeyEvent` matches when `KeyCode::Char(c)` has `c.is_uppercase()` and the event does **not** carry `KeyModifiers::SHIFT`. With the kitty keyboard-enhancement flags active (`DISAMBIGUATE_ESCAPE_CODES`, pushed in `src/tui.rs` when the terminal supports it), a genuine Shift+letter always arrives *with* the SHIFT modifier — confirmed by the existing `(KeyModifiers::SHIFT, KeyCode::Char(uppercase))` bindings throughout `keybindings.rs` — so real Shift+letter never matches. Release events never match (already filtered upstream, but checked defensively).

On legacy terminals without the enhancement, crossterm's parser may infer SHIFT for any uppercase byte, including CapsLock-produced ones. In that case detection simply never fires — silent degradation, not something worth working around per the task brief.

## Editing-context gate

The hint must never fire while the user is legitimately typing uppercase text. `is_text_editing_context` (`src/keybindings.rs`) mirrors the same mode/flag routing `map_key_to_action` uses to reach its text-capturing handlers: the commit-message editor, `AppMode::Input` (branch/tag/search), the graph/files text filters, PR/issue compose, the command palette, and the settings query.

Both are pure and unit-tested independently of `App`.

## Wiring + rate limit

`App::maybe_hint_capslock` (`src/app/status_message.rs`) composes the two pure checks with a 30s cooldown (`last_capslock_hint: Option<Instant>` on `App`, not persisted) so a held or repeated caps-locked key doesn't spam a toast per keystroke. Called from both real input (`src/main.rs`) and the debug-server key-injection path (`src/debug_server.rs`), ahead of `map_key_to_action`, so it fires regardless of whether the key ends up mapping to an action — capslock while navigating means most bindings are broken anyway.

Toast: `Info`, "CapsLock appears to be on — keys are case-sensitive".

## Tests

- `src/keybindings.rs`: `capslock_signature_is_uppercase_letter_without_shift`, `genuine_shift_uppercase_is_not_capslock`, `lowercase_is_never_capslock`, `non_alphabetic_chars_are_never_capslock`, `release_events_are_never_capslock`, `repeat_events_can_be_capslock`, `non_char_keys_are_never_capslock`, plus `is_text_editing_context` coverage (`commit_editor_is_a_text_editing_context`, `active_filters_are_text_editing_contexts`, `text_capturing_modes_are_editing_contexts`, `plain_navigation_modes_are_not_editing_contexts`).
- `src/app/status_message.rs` (`capslock_hint_tests`, App-level): `capslock_signature_key_in_normal_mode_toasts`, `no_toast_while_editing_commit_message`, `no_toast_while_a_text_filter_is_active`, `no_toast_while_input_mode_is_capturing_text`, `second_capslock_key_within_cooldown_does_not_toast_again`, `genuine_shift_uppercase_never_toasts`.

`cargo test` (1248 passed) and `cargo clippy --all-targets` (clean) both pass.

## TUI verification

Launched headlessly via `--debug-listen` and drove it through the remote-control protocol. **Limitation:** the debug key-injection protocol's single-character tokens always imply SHIFT for uppercase letters (documented in `docs/debugging.md`: "single characters are sent as-is (uppercase implies Shift)") — there is no way to inject a bare uppercase `Char` without the SHIFT modifier over that wire protocol, so the positive-fire path (the actual CapsLock signature) can't be exercised end-to-end through this harness. That path is covered by the unit/App-level tests above instead.

What I did verify live: sent `O` (Shift+O → `ToggleRemoteBranches`) through the debug server with the new `maybe_hint_capslock` call now sitting in the input path ahead of `map_key_to_action` in both `main.rs` and `debug_server.rs`. The existing Shift+O binding still worked correctly (remote branches toggled, confirmed via `dump`), no CapsLock toast appeared (correct — SHIFT was present), and the app exited cleanly with no panics in the log.

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)