### PR TITLE
fix(graph): squash link joins the uncommitted band via a ┬ junction (#115)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -164,10 +164,10 @@ runs in two phases:
    flanking commit dot, classified as *hubs* (row mid-height: a flanking dot,
    or a `TeeRight`/`TeeLeft` that stays on the trunk with no flanking dot — a
    fork connector's trunk, whose up-arms fan from it) or *spokes* (a row edge:
-   `Merge*`/`TeeUp` turning up to the top edge, `Branch*` turning down to the
-   bottom edge, and a `Tee{Right,Left}` that *is* flanked by a dot — that Tee is
-   the commit's parent-connector into a still-descending trunk, so it sweeps
-   down to the bottom edge like a `Branch*` rather than staying flat). One
+   `Merge*`/`TeeUp` turning up to the top edge, `Branch*` and `TeeDown` turning
+   down to the bottom edge, and a `Tee{Right,Left}` that *is* flanked by a dot —
+   that Tee is the commit's parent-connector into a still-descending trunk, so
+   it sweeps down to the bottom edge like a `Branch*` rather than staying flat). One
    cubic is drawn from the run's primary hub to each spoke (a branch/merge is
    the 2-endpoint case → one curve; a fork connector `├─┴─╯` fans several);
    with no hub the spokes are chained pairwise; a lone hub/spoke with nothing
@@ -203,6 +203,25 @@ Curve endpoints are exact lane centers on row edges (spokes) or dot centers
 the dot it belongs to. Because `transition_curves` is pure over the cells,
 drawing stays a deterministic function of the `RowSpec`, so the protocol cache
 stays correct. Unicode mode is unchanged (box glyphs can't curve).
+
+**Squash link joins the uncommitted band via `TeeDown` (2026-07-22, #115).**
+When HEAD sits on a squash-merge target with uncommitted changes, two layout
+overlays land on the same row: the uncommitted node's horizontal landing band
+and the squash link — and the band sits geometrically *between* the link's
+endpoints, so no clean column exists. The overlay writers can only cross
+`Pipe` cells (`HorizontalPipe`); anything else used to force the link onto a
+fresh far lane (the #110 phantom-detour shape) while the crossing run was
+silently severed by the band, leaving orphan curve fragments in both
+renderers. `draw_squash_link` now *joins* the band instead: a
+`CellType::TeeDown(band_color, stem_color)` junction (┬) on the tip's own lane
+lets the band carry the link into the target dot while the stem drops straight
+into the tip dot. Junction preconditions (`junction_ok`): the blocking cell is
+an overlay `Horizontal` with no trace edges, and every cell between it and the
+target dot is horizontal-family (a continuous corridor). The pixel renderer
+treats `TeeDown` as a down-spoke (its stem is the SECONDARY stroke, like a
+`Tee*` arm), so `transition_curves` draws one grey S from the target dot into
+the tip dot. The mirror orientation (band on the *lower* endpoint row) has no
+junction cell and keeps the old fallback.
 
 **Uncommitted connector survives the commit filter (2026-07-19).** The synthetic
 uncommitted-changes node always passes the commit filter, and its connector is

--- a/examples/dump_cells.rs
+++ b/examples/dump_cells.rs
@@ -16,6 +16,7 @@ fn glyph(c: &CellType) -> String {
         CellType::TeeRight(i) => format!("TR{i}"),
         CellType::TeeLeft(i) => format!("TL{i}"),
         CellType::TeeUp(i) => format!("TU{i}"),
+        CellType::TeeDown(h, s) => format!("TD{h}/{s}"),
         CellType::HorizontalPipe(h, p) => format!("H{h}P{p}"),
         CellType::Commit(i) => format!(" @{i}"),
     }

--- a/src/git/graph.rs
+++ b/src/git/graph.rs
@@ -99,6 +99,14 @@ pub enum CellType {
     TeeLeft(usize),
     /// Upward T junction (fork point) ┴
     TeeUp(usize),
+    /// Downward T junction ┬: a stem (`.1`) drops out of a horizontal corridor
+    /// (`.0` keeps the corridor's color) toward the row below. Written only by
+    /// [`draw_squash_link`] when the link's natural anchor column is occupied
+    /// on the far endpoint's row by a horizontal run that flows into that
+    /// endpoint's dot (the uncommitted landing band across the HEAD row): the
+    /// link *joins* the band instead of detouring around it (issue #115). Both
+    /// strokes are overlay decorations — the cell keeps `(None, None)` edges.
+    TeeDown(usize, usize), // (horizontal_color, stem_color)
 }
 
 /// Graph layout
@@ -894,6 +902,13 @@ fn inject_squash_links(nodes: &mut [GraphNode], max_lane: &mut usize, links: &[(
 /// so the link detoured out and back — a phantom curve ending in a void column
 /// (issue #110). Anchoring on an endpoint's own column removes that detour.
 ///
+/// When even the endpoint anchors are blocked because the upper row carries a
+/// horizontal run into the upper dot (the uncommitted landing band, when HEAD
+/// sits on the squash commit with uncommitted changes), the link JOINS the run
+/// via a [`CellType::TeeDown`] junction instead of detouring (issue #115) —
+/// see `junction_ok` below. The mirror orientation (band on the *lower*
+/// endpoint's row) has no junction cell yet and keeps the old fallback.
+///
 /// See [`inject_squash_links`] for the invariants this preserves.
 fn draw_squash_link(nodes: &mut [GraphNode], max_lane: &mut usize, r1: usize, r2: usize) {
     let (u, l) = (r1.min(r2), r1.max(r2));
@@ -922,6 +937,49 @@ fn draw_squash_link(nodes: &mut [GraphNode], max_lane: &mut usize, r1: usize, r2
                 == CellType::Empty
         })
     };
+    // Junction fallback (issue #115): when the lower endpoint's own lane is
+    // blocked ONLY on the upper row, and what blocks it is a horizontal run
+    // flowing into the upper dot (the uncommitted landing band across the HEAD
+    // row — exactly what happens when HEAD sits on the squash commit with
+    // uncommitted changes), the link can JOIN that run instead of detouring: a
+    // ┬ stem drops out of the band straight into the lower dot, and the band
+    // itself carries the link the rest of the way into the upper dot. Only an
+    // overlay horizontal (no trace edges) is joinable; a real merge-arm cell
+    // keeps its cell untouched and the old routing applies.
+    let junction_ok = |nodes: &[GraphNode]| -> bool {
+        if llane == ulane {
+            return false;
+        }
+        let ci = llane * 2;
+        let cell = |row: usize, col: usize| {
+            nodes[row].cells.get(col).copied().unwrap_or(CellType::Empty)
+        };
+        // Intermediate rows must be free for the stem's pipe.
+        if !((u + 1)..l).all(|i| cell(i, ci) == CellType::Empty) {
+            return false;
+        }
+        // The junction cell: an overlay horizontal, never a traceable edge.
+        if !matches!(cell(u, ci), CellType::Horizontal(_)) {
+            return false;
+        }
+        if nodes[u].cell_oids.get(ci).copied().unwrap_or((None, None)) != (None, None) {
+            return false;
+        }
+        // Corridor: every cell between the upper dot and the junction is part
+        // of one continuous horizontal run, so the band reaches the dot.
+        let (lo, hi) = if llane > ulane {
+            (ulane * 2 + 1, ci)
+        } else {
+            (ci + 1, ulane * 2)
+        };
+        (lo..hi).all(|col| {
+            matches!(
+                cell(u, col),
+                CellType::Horizontal(_) | CellType::HorizontalPipe(_, _)
+            )
+        })
+    };
+
     // Prefer the usable lane nearest both endpoints (fewest crossings, and it
     // keeps the connector between/on the endpoints rather than detouring out);
     // `max_lane + 1` is always free as a last-resort fallback.
@@ -935,6 +993,13 @@ fn draw_squash_link(nodes: &mut [GraphNode], max_lane: &mut usize, r1: usize, r2
                 link_lane = cand;
             }
         }
+    }
+    // The band junction wins whenever it is tighter than the best clean
+    // column — in the colliding topology the clean fallback is a far detour
+    // lane, the #110 phantom shape this junction exists to avoid.
+    let junction = junction_ok(nodes) && llane.abs_diff(ulane) < best_dist;
+    if junction {
+        link_lane = llane;
     }
 
     if link_lane > *max_lane {
@@ -960,6 +1025,18 @@ fn draw_squash_link(nodes: &mut [GraphNode], max_lane: &mut usize, r1: usize, r2
             node.cells[gcol] = CellType::Pipe(SQUASH_LINK_COLOR_INDEX);
             node.cell_oids[gcol] = (None, None);
         }
+    }
+
+    // Band junction: replace the corridor cell with a ┬ whose stem drops into
+    // the lower dot (anchored on its own lane — no lower elbow, no crossing
+    // runs on either endpoint row; the band already reaches the upper dot).
+    if junction {
+        let CellType::Horizontal(band) = nodes[u].cells[gcol] else {
+            unreachable!("junction_ok verified an overlay Horizontal at the junction cell");
+        };
+        nodes[u].cells[gcol] = CellType::TeeDown(band, SQUASH_LINK_COLOR_INDEX);
+        // cell_oids stay (None, None): both strokes are untraceable overlays.
+        return;
     }
 
     // Upper endpoint: the link leaves this commit and heads down the link lane.
@@ -2245,6 +2322,9 @@ mod tests {
             | CellType::TeeLeft(c)
             | CellType::TeeUp(c)
             | CellType::HorizontalPipe(c, _) => Some(c),
+            // The stem is the junction's own stroke; the horizontal belongs
+            // to the corridor it joined.
+            CellType::TeeDown(_, s) => Some(s),
         }
     }
 
@@ -2474,6 +2554,204 @@ mod tests {
             CellType::BranchLeft(SQUASH_LINK_COLOR_INDEX)
                 | CellType::BranchRight(SQUASH_LINK_COLOR_INDEX)
         ));
+    }
+
+    /// #115 repro shape: HEAD sits ON the squash commit `S` with uncommitted
+    /// changes. Lanes 0 and 1 are busy above HEAD (children X, Y of S), so the
+    /// uncommitted node lands on a farther lane and its horizontal band crosses
+    /// the tip's lane column on S's row. The link must JOIN the band with a ┬
+    /// junction on the tip's own lane — not detour to a fresh far lane, not
+    /// sever the band, and not scatter grey fragments on either endpoint row.
+    #[test]
+    fn squash_link_joins_uncommitted_band_with_tee_down_junction() {
+        let (x, y, s, f, t, z) = (oid(1), oid(2), oid(3), oid(4), oid(5), oid(6));
+        let commits = vec![
+            ci(x, vec![s]), // newest child of S — keeps HEAD's own lane busy above
+            ci(y, vec![s]), // second child of S — keeps the next lane busy too
+            ci(s, vec![t]), // squash commit = HEAD, uncommitted changes present
+            ci(f, vec![t]), // squash-merged feature tip, one row below S
+            ci(t, vec![z]),
+            ci(z, vec![]),
+        ];
+        let unc = Some(Some(1));
+        let base = build_graph(&commits, &[], &[], &[], unc, Some(s), &[]);
+        let linked = build_graph(&commits, &[], &[], &[], unc, Some(s), &[(f, s)]);
+
+        let sr = row_of(&linked, s);
+        let fr = row_of(&linked, f);
+        let flane = linked.nodes[fr].lane;
+        let gcol = flane * 2;
+
+        // Fixture precondition: the uncommitted landing band crosses the tip's
+        // lane column on S's row as a plain overlay horizontal. If lane
+        // assignment ever changes and this stops holding, the test needs a new
+        // topology — fail loudly rather than silently testing nothing.
+        assert!(
+            matches!(
+                base.nodes[sr].cells[gcol],
+                CellType::Horizontal(UNCOMMITTED_COLOR_INDEX)
+            ),
+            "fixture must put the uncommitted band across the tip lane on S's row, got {:?}",
+            base.nodes[sr].cells[gcol]
+        );
+
+        // The junction replaces the band cell: corridor color preserved, stem
+        // in the link grey, edges still untraceable.
+        assert_eq!(
+            linked.nodes[sr].cells[gcol],
+            CellType::TeeDown(UNCOMMITTED_COLOR_INDEX, SQUASH_LINK_COLOR_INDEX),
+            "the link joins the band via a ┬ junction on the tip's lane"
+        );
+        assert_eq!(linked.nodes[sr].cell_oids[gcol], (None, None));
+
+        // No detour: the graph does not widen by a link lane.
+        assert_eq!(
+            linked.max_lane, base.max_lane,
+            "joining the band must not add a detour lane"
+        );
+
+        // The junction is the ONLY link-grey ink: no crossing runs, no elbows,
+        // no fragments anywhere else (S and F are adjacent rows, so not even a
+        // pipe is needed).
+        for (i, node) in linked.nodes.iter().enumerate() {
+            for (c, cell) in node.cells.iter().enumerate() {
+                if cell_color(*cell) == Some(SQUASH_LINK_COLOR_INDEX) {
+                    assert_eq!(
+                        (i, c),
+                        (sr, gcol),
+                        "the ┬ stem is the link's only stroke, found extra grey at row {i} col {c}: {cell:?}"
+                    );
+                }
+            }
+        }
+
+        // Every other cell is byte-identical to the link-off layout — the band
+        // stays whole and the tip row carries no crossing run.
+        for (i, (b, l)) in base.nodes.iter().zip(&linked.nodes).enumerate() {
+            for (c, (bc, lc)) in b.cells.iter().zip(&l.cells).enumerate() {
+                if (i, c) != (sr, gcol) {
+                    assert_eq!(bc, lc, "cell at row {i} col {c} must be untouched");
+                }
+            }
+        }
+    }
+
+    /// Multi-row variant of the junction: the tip sits more than one row below
+    /// the squash commit, so the ┬ stem continues as grey pipes through the
+    /// intermediate rows before anchoring on the tip dot.
+    #[test]
+    fn squash_link_junction_stem_spans_intermediate_rows() {
+        let (x, y, w, s, m, f, t, z) = (
+            oid(1),
+            oid(2),
+            oid(3),
+            oid(4),
+            oid(5),
+            oid(6),
+            oid(7),
+            oid(8),
+        );
+        let commits = vec![
+            ci(x, vec![s]), // children of S keep the near lanes busy above HEAD,
+            ci(y, vec![s]), // pushing the uncommitted node PAST the tip's lane so
+            ci(w, vec![s]), // its band crosses that lane as a plain horizontal
+            ci(s, vec![t]), // squash commit = HEAD
+            ci(m, vec![t]), // an unrelated branch row between S and the tip
+            ci(f, vec![t]), // squash-merged feature tip, ≥2 rows below S
+            ci(t, vec![z]),
+            ci(z, vec![]),
+        ];
+        let unc = Some(Some(1));
+        let base = build_graph(&commits, &[], &[], &[], unc, Some(s), &[]);
+        let linked = build_graph(&commits, &[], &[], &[], unc, Some(s), &[(f, s)]);
+
+        let sr = row_of(&linked, s);
+        let fr = row_of(&linked, f);
+        let flane = linked.nodes[fr].lane;
+        let gcol = flane * 2;
+
+        // Fixture preconditions: at least one intermediate row, and the band
+        // crosses the tip's lane column on S's row as a plain overlay cell.
+        assert!(fr > sr + 1, "fixture must put intermediate rows between S and F");
+        assert!(
+            matches!(
+                base.nodes[sr].cells[gcol],
+                CellType::Horizontal(UNCOMMITTED_COLOR_INDEX)
+            ),
+            "fixture must put the uncommitted band across the tip lane, got {:?}",
+            base.nodes[sr].cells[gcol]
+        );
+
+        assert_eq!(
+            linked.nodes[sr].cells[gcol],
+            CellType::TeeDown(UNCOMMITTED_COLOR_INDEX, SQUASH_LINK_COLOR_INDEX)
+        );
+        assert_eq!(linked.max_lane, base.max_lane, "no detour lane");
+        // The stem runs as a grey pipe through every intermediate row and the
+        // tip dot anchors it; that stem is the link's ONLY grey ink.
+        for i in (sr + 1)..fr {
+            assert_eq!(
+                linked.nodes[i].cells[gcol],
+                CellType::Pipe(SQUASH_LINK_COLOR_INDEX),
+                "intermediate row {i} carries the stem pipe"
+            );
+        }
+        assert!(matches!(linked.nodes[fr].cells[gcol], CellType::Commit(_)));
+        for (i, node) in linked.nodes.iter().enumerate() {
+            for (c, cell) in node.cells.iter().enumerate() {
+                if cell_color(*cell) == Some(SQUASH_LINK_COLOR_INDEX) {
+                    assert!(
+                        c == gcol && i >= sr && i < fr,
+                        "unexpected grey ink at row {i} col {c}: {cell:?}"
+                    );
+                }
+            }
+        }
+    }
+
+    /// When the cell blocking the tip's lane on S's row is the uncommitted
+    /// landing CURVE (not a band horizontal), there is no corridor to join —
+    /// the junction must not fire, and the old routing applies untouched.
+    #[test]
+    fn squash_link_junction_refuses_the_landing_curve() {
+        let (x, s, f, t, z) = (oid(1), oid(2), oid(3), oid(4), oid(5));
+        let commits = vec![
+            ci(x, vec![s]), // keeps HEAD's lane busy above, nothing else —
+            ci(s, vec![t]), // so the uncommitted node lands on the NEXT lane
+            ci(f, vec![t]), // and its ╯ curve sits exactly on the tip's column
+            ci(t, vec![z]),
+            ci(z, vec![]),
+        ];
+        let unc = Some(Some(1));
+        let base = build_graph(&commits, &[], &[], &[], unc, Some(s), &[]);
+        let linked = build_graph(&commits, &[], &[], &[], unc, Some(s), &[(f, s)]);
+
+        let sr = row_of(&linked, s);
+        let fr = row_of(&linked, f);
+        let flane = linked.nodes[fr].lane;
+
+        // Fixture precondition: the landing curve occupies the tip's column.
+        assert!(
+            matches!(
+                base.nodes[sr].cells[flane * 2],
+                CellType::MergeLeft(UNCOMMITTED_COLOR_INDEX)
+            ),
+            "fixture must land the uncommitted curve on the tip lane, got {:?}",
+            base.nodes[sr].cells[flane * 2]
+        );
+
+        // No junction — a curve cannot host a stem.
+        assert!(
+            !linked.nodes.iter().any(|n| n
+                .cells
+                .iter()
+                .any(|c| matches!(c, CellType::TeeDown(_, _)))),
+            "the junction must not compose with a landing curve"
+        );
+        // The landing curve itself survives verbatim.
+        assert_eq!(base.nodes[sr].cells[flane * 2], linked.nodes[sr].cells[flane * 2]);
+        // And the link still drew, somewhere, without panicking.
+        assert!(has_squash_grey(&linked));
     }
 
     #[test]

--- a/src/ui/graph_pixels.rs
+++ b/src/ui/graph_pixels.rs
@@ -43,6 +43,9 @@ pub enum CellShape {
     TeeRight,
     TeeLeft,
     TeeUp,
+    /// Band junction (#115): horizontal corridor (primary stroke) with a stem
+    /// (secondary stroke) dropping to the row below, like a `Branch*` spoke.
+    TeeDown,
     Commit {
         connect_up: bool,
         connect_down: bool,
@@ -138,6 +141,7 @@ fn cell_touches_bottom(cell: &CellType) -> bool {
             | CellType::HorizontalPipe(_, _)
             | CellType::TeeRight(_)
             | CellType::TeeLeft(_)
+            | CellType::TeeDown(_, _)
     )
 }
 
@@ -264,6 +268,19 @@ fn cell_to_pixel(
         CellType::TeeRight(ci) => solid(CellShape::TeeRight, rgb(ci)),
         CellType::TeeLeft(ci) => solid(CellShape::TeeLeft, rgb(ci)),
         CellType::TeeUp(ci) => solid(CellShape::TeeUp, rgb(ci)),
+        // Band junction (#115): corridor color is the primary stroke (it is
+        // the run body `run_style` reads), the stem is the secondary — the
+        // down-spoke `transition_curves` builds takes `secondary`.
+        CellType::TeeDown(h, s) => PixelCell {
+            shape: CellShape::TeeDown,
+            color: rgb(h),
+            secondary: rgb(s),
+            dim: false,
+            dim_secondary: false,
+            curved_above: false,
+            curved_below: false,
+            spoke_on_dot: false,
+        },
         CellType::HorizontalPipe(h, p) => PixelCell {
             shape: CellShape::HorizontalPipe,
             color: rgb(p),
@@ -313,7 +330,12 @@ fn cell_to_pixel(
         CellShape::Pipe | CellShape::HorizontalPipe | CellShape::Commit { .. }
     ) {
         px.curved_above = above.and_then(|c| c.get(col)).is_some_and(|c| {
-            matches!(c, CellType::BranchLeft(_) | CellType::BranchRight(_))
+            matches!(
+                c,
+                CellType::BranchLeft(_)
+                    | CellType::BranchRight(_)
+                    | CellType::TeeDown(_, _)
+            )
         });
         px.curved_below = below.and_then(|c| c.get(col)).is_some_and(|c| {
             matches!(
@@ -338,7 +360,8 @@ fn cell_to_pixel(
         CellShape::BranchLeft
         | CellShape::BranchRight
         | CellShape::TeeLeft
-        | CellShape::TeeRight => {
+        | CellShape::TeeRight
+        | CellShape::TeeDown => {
             px.spoke_on_dot = is_dot(below);
         }
         _ => {}
@@ -822,6 +845,7 @@ fn has_horizontal(shape: CellShape) -> bool {
             | CellShape::TeeLeft
             | CellShape::TeeRight
             | CellShape::TeeUp
+            | CellShape::TeeDown
     )
 }
 
@@ -956,6 +980,19 @@ fn transition_curves(cells: &[PixelCell], cw: f32, ch: f32) -> Vec<Curve> {
                 }
                 CellShape::TeeUp => {
                     spokes.push(Endpoint { x: cx(c), y: above_cy, color, dim, on_dot: cell.spoke_on_dot });
+                }
+                CellShape::TeeDown => {
+                    // Band junction (#115): the stem is a down-spoke out of the
+                    // corridor, carried in the SECONDARY stroke (the corridor
+                    // itself is the run body). With a dot hub flanking the run
+                    // this draws one S from that dot down into the stem's dot.
+                    spokes.push(Endpoint {
+                        x: cx(c),
+                        y: below_cy,
+                        color: cell.secondary,
+                        dim: cell.dim_secondary,
+                        on_dot: cell.spoke_on_dot,
+                    });
                 }
                 CellShape::TeeRight | CellShape::TeeLeft => {
                     // A Tee's trunk continues DOWN to a not-yet-shown parent (the
@@ -1193,7 +1230,8 @@ fn draw_cells(
             | CellShape::BranchLeft
             | CellShape::MergeRight
             | CellShape::MergeLeft
-            | CellShape::TeeUp => {}
+            | CellShape::TeeUp
+            | CellShape::TeeDown => {}
         }
     }
 }

--- a/src/ui/graph_view/mod.rs
+++ b/src/ui/graph_view/mod.rs
@@ -451,6 +451,10 @@ fn render_cells_unicode(
             CellType::TeeRight(color_idx) => ('├', theme.lane_color(*color_idx)),
             CellType::TeeLeft(color_idx) => ('┤', theme.lane_color(*color_idx)),
             CellType::TeeUp(color_idx) => ('┴', theme.lane_color(*color_idx)),
+            // Band junction (#115): the stem is the distinguishing stroke.
+            CellType::TeeDown(_h_color_idx, s_color_idx) => {
+                ('┬', theme.lane_color(*s_color_idx))
+            }
         };
 
         // Line glyphs render bold; non-lineage cells dim while tracing.

--- a/src/ui/graph_view/pixel_dim.rs
+++ b/src/ui/graph_view/pixel_dim.rs
@@ -286,14 +286,21 @@ fn dim_specs_window_core(
                         let slice = if c.from_underlay { &n.underlay } else { &n.cells };
                         slice.get(c.col as usize)
                     }) {
-                        c.color = cell.color;
+                        // A TeeDown's boundary-crossing curve is its STEM,
+                        // carried in the secondary stroke (#115).
+                        c.color = match cell.shape {
+                            crate::ui::graph_pixels::CellShape::TeeDown => cell.secondary,
+                            _ => cell.color,
+                        };
                         // A Tee source cell's boundary-crossing curve is its
                         // ARM (the trunk is a straight through-line that never
                         // crosses as a curve), so the tail follows the arm's
-                        // flag (#113).
+                        // flag (#113); a TeeDown's stem likewise styles via
+                        // `dim_secondary`.
                         c.dim = match cell.shape {
                             crate::ui::graph_pixels::CellShape::TeeRight
-                            | crate::ui::graph_pixels::CellShape::TeeLeft => cell.dim_secondary,
+                            | crate::ui::graph_pixels::CellShape::TeeLeft
+                            | crate::ui::graph_pixels::CellShape::TeeDown => cell.dim_secondary,
                             _ => cell.dim,
                         };
                     }

--- a/tests/graph_test.rs
+++ b/tests/graph_test.rs
@@ -55,6 +55,7 @@ fn render_cells(cells: &[CellType]) -> String {
             CellType::TeeRight(_) => '├',
             CellType::TeeLeft(_) => '┤',
             CellType::TeeUp(_) => '┴',
+            CellType::TeeDown(_, _) => '┬',
         })
         .collect()
 }


### PR DESCRIPTION
Closes #115

## Problem

Detached HEAD exactly on a squash-merge target + uncommitted changes + squash link lines on: the uncommitted node's horizontal landing band crosses the link's anchor column on the HEAD row. The link router (`column_ok`) only accepts fully-empty columns, so it detoured to a fresh far lane (the #110 phantom shape, resurrected), and `squash_cross_row` — which can only cross `Empty`/`Pipe` — silently severed the grey run across the band. Result: two crossing S-curves ending in empty space in the pixel renderer, plus an orphan vertical stub under the band's landing curve (bc478cc family).

## Fix

New `CellType::TeeDown(band_color, stem_color)` (┬). When the tip's own lane is blocked only by an overlay horizontal whose run demonstrably reaches the target dot, `draw_squash_link` **joins** the band instead of detouring: ┬ on the tip's lane, stem dropping straight into the tip dot, the band carrying the link the rest of the way into the target dot. `junction_ok` is conservative (overlay `Horizontal` with `(None,None)` edges, continuous horizontal-family corridor, free intermediate rows) — anything else keeps the old routing.

Renderers: unicode draws `┬` in the stem color; the pixel path treats `TeeDown` as horizontal-family + a down-spoke whose stem is the SECONDARY stroke, so `transition_curves` produces one grey S from the target dot into the tip dot. Trace/merged dim passes no-op on it (`(None, None)` edges), matching existing squash-grey behavior. Mirror orientation (band on the *lower* endpoint row) has no junction cell yet and keeps the old fallback — documented in code and `architecture.md`.

## Verification

- 3 new layout tests: junction shape + only-grey-ink + byte-identical-elsewhere; multi-row stem; negative test (landing curve refuses the junction). 1234 tests + clippy green.
- Live repro against the actual reported repo state (detached at the squash target, dirty tree) via the debug server: star row renders `⭐ ┬─────────────╯`, tip row clean.
- Pixel path rendered through the real rasterizer (`raster_debug`-derived harness): before shows the crossing orphan curves, after shows one continuous band + stem.
- Adversarial review subagent: no confirmed issues across junction preconditions, match-site coverage (incl. `matches!` sites the compiler can't flag), degenerate run shapes, and `RowSpec` cache hashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AS6BcyQCBtzasjqCLquG2