### PR TITLE
feat(ui): hideable files and commit-detail panes

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -47,6 +47,10 @@ pub enum Action {
     ToggleRemoteBranches,
     /// Show/hide branches already merged into the trunk (merge/squash) in the graph.
     ToggleMergedBranches,
+    /// Show/hide the files pane (#116); the freed space goes to its neighbors.
+    ToggleFilesPane,
+    /// Show/hide the commit-detail pane (#116).
+    ToggleCommitPane,
     MenuSelect,
     SelectAll,
     SelectNone,

--- a/src/app/commit_menu_actions.rs
+++ b/src/app/commit_menu_actions.rs
@@ -107,7 +107,7 @@ impl App {
 
         if node.is_uncommitted {
             // For uncommitted node, go to files panel
-            self.focused_panel = FocusedPanel::Files;
+            self.focus_files_pane();
             return;
         }
 

--- a/src/app/conflict_actions.rs
+++ b/src/app/conflict_actions.rs
@@ -158,7 +158,7 @@ impl App {
             self.graph_nav.graph_list_state.select(Some(0));
             self.graph_nav.selected_branch_position = None;
         }
-        self.focused_panel = FocusedPanel::Files;
+        self.focus_files_pane();
         // The async uncommitted diff may not have run yet; compute the quick
         // file list synchronously so conflicts show without a frame delay.
         self.diff_cache.set_quick_uncommitted(self.repo.repo());
@@ -242,6 +242,25 @@ mod tests {
     use crate::app::App;
     use crate::git::{GitRepository, OperationState};
     use crate::test_support::git;
+
+    /// #116: conflict guidance routes the user to the files pane; if that pane
+    /// is hidden, it must be un-hidden — focus landing on an invisible pane
+    /// would strand input with no visible cue.
+    #[test]
+    fn conflict_focus_unhides_a_hidden_files_pane() {
+        let tmp = tempfile::tempdir().unwrap();
+        git(tmp.path(), &["init", "-q", "-b", "main"]);
+        std::fs::write(tmp.path().join("f.txt"), "x\n").unwrap();
+        git(tmp.path(), &["add", "."]);
+        git(tmp.path(), &["commit", "-q", "-m", "init"]);
+        let repo = GitRepository::open(tmp.path()).unwrap();
+        let mut app = App::from_repo(repo).unwrap();
+
+        app.hide_files_pane = true;
+        app.focus_conflict_files();
+        assert!(!app.hide_files_pane, "conflict flow must reveal the files pane");
+        assert_eq!(app.focused_panel, crate::app::FocusedPanel::Files);
+    }
 
     // ── Pure predicate: op_guard_message ────────────────────────────────
 

--- a/src/app/file_diff_actions.rs
+++ b/src/app/file_diff_actions.rs
@@ -189,7 +189,7 @@ impl App {
                     self.sync_file_list_cache();
                     self.select_file_at(self.flat_index_to_display_index(fi));
                 }
-                self.focused_panel = FocusedPanel::Files;
+                self.focus_files_pane();
                 self.return_to_normal();
             }
             _ => {}
@@ -364,7 +364,7 @@ impl App {
         if new_file_list.is_empty() {
             self.diff_source = None;
             self.mode = AppMode::Normal;
-            self.focused_panel = FocusedPanel::Files;
+            self.focus_files_pane();
             self.toast(crate::toast::ToastKind::Info, "No changes remaining");
             return Ok(());
         }

--- a/src/app/file_history_actions.rs
+++ b/src/app/file_history_actions.rs
@@ -97,7 +97,7 @@ impl App {
             }
             Action::Cancel | Action::Quit => {
                 self.mode = AppMode::Normal;
-                self.focused_panel = FocusedPanel::Files;
+                self.focus_files_pane();
             }
             _ => {}
         }

--- a/src/app/graph_actions.rs
+++ b/src/app/graph_actions.rs
@@ -16,20 +16,13 @@ impl App {
         match action {
             Action::PanelLeft => {
                 self.editing_commit_message = false;
-                self.focused_panel = match self.focused_panel {
-                    FocusedPanel::Graph => FocusedPanel::CommitDetail,
-                    FocusedPanel::CommitDetail => FocusedPanel::Files,
-                    FocusedPanel::Files => FocusedPanel::Graph,
-                };
+                // Cycle only through visible panels (#116).
+                self.focused_panel = self.next_visible_panel(self.focused_panel, false);
                 return Ok(());
             }
             Action::PanelRight => {
                 self.editing_commit_message = false;
-                self.focused_panel = match self.focused_panel {
-                    FocusedPanel::Graph => FocusedPanel::Files,
-                    FocusedPanel::Files => FocusedPanel::CommitDetail,
-                    FocusedPanel::CommitDetail => FocusedPanel::Graph,
-                };
+                self.focused_panel = self.next_visible_panel(self.focused_panel, true);
                 return Ok(());
             }
             Action::FocusGraph => {
@@ -45,6 +38,16 @@ impl App {
             // The issue list opens from any panel in Normal mode.
             Action::OpenIssueList => {
                 self.open_issue_list();
+                return Ok(());
+            }
+            // Pane visibility toggles work from any panel (#116) — hiding the
+            // focused pane moves focus to the graph inside the toggle.
+            Action::ToggleFilesPane => {
+                self.toggle_files_pane();
+                return Ok(());
+            }
+            Action::ToggleCommitPane => {
+                self.toggle_commit_pane();
                 return Ok(());
             }
             // Palette shortcut: open (or reuse) the list, then the new-issue

--- a/src/app/init.rs
+++ b/src/app/init.rs
@@ -193,7 +193,9 @@ impl App {
             graph_layout,
             graph_generation: 0,
             graph_nav,
-            focused_panel: if ui_state.side_panel_layout {
+            // A hidden files pane must not hold startup focus (#116) — the
+            // side-layout default only applies while that pane is visible.
+            focused_panel: if ui_state.side_panel_layout && !ui_state.hide_files_pane {
                 FocusedPanel::Files
             } else {
                 FocusedPanel::Graph
@@ -268,6 +270,8 @@ impl App {
             repo_dirty: false,
             last_undoable_op: None,
             side_panel_layout: ui_state.side_panel_layout,
+            hide_files_pane: ui_state.hide_files_pane,
+            hide_commit_pane: ui_state.hide_commit_pane,
             hide_remote_branches: ui_state.hide_remote_branches,
             hide_stashes: ui_state.hide_stashes,
             merged: MergedState {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1109,6 +1109,15 @@ pub struct App {
     // Layout
     pub side_panel_layout: bool,
 
+    /// Hide the files pane entirely (#116). Persisted in `UiState`. Focus and
+    /// mouse hit-testing must never land on a hidden pane; flows that
+    /// explicitly navigate to files (conflicts, "go to files") un-hide it
+    /// instead of silently no-opping.
+    pub hide_files_pane: bool,
+
+    /// Hide the commit-detail pane entirely (#116). Persisted in `UiState`.
+    pub hide_commit_pane: bool,
+
     /// When true, remote-only branches (remote refs with no matching local
     /// branch) are hidden from the graph — their labels and their exclusive
     /// commits. Composes with `hidden_branches`. Persisted in `UiState`.
@@ -1544,6 +1553,76 @@ impl App {
     /// Toggle whether remote-only branches are shown in the graph (persisted).
     /// Rebuilds the graph so their exclusive commits appear/disappear, not just
     /// their labels. Composes with the per-branch filter.
+    /// Whether a panel is currently visible — the invariant every focus path
+    /// (cycling, mouse, force-focus) must respect: focus never lands on a
+    /// hidden pane (#116). The graph is always visible.
+    pub(crate) fn panel_visible(&self, panel: FocusedPanel) -> bool {
+        match panel {
+            FocusedPanel::Graph => true,
+            FocusedPanel::Files => !self.hide_files_pane,
+            FocusedPanel::CommitDetail => !self.hide_commit_pane,
+        }
+    }
+
+    /// The next visible panel in cycle order from `from` (forward = the
+    /// PanelRight direction Graph → Files → CommitDetail). Falls back to the
+    /// graph, which is always visible.
+    pub(crate) fn next_visible_panel(&self, from: FocusedPanel, forward: bool) -> FocusedPanel {
+        let forward_order = [
+            FocusedPanel::Graph,
+            FocusedPanel::Files,
+            FocusedPanel::CommitDetail,
+        ];
+        let pos = forward_order.iter().position(|p| *p == from).unwrap_or(0);
+        let step = if forward { 1 } else { forward_order.len() - 1 };
+        let mut at = pos;
+        for _ in 0..forward_order.len() {
+            at = (at + step) % forward_order.len();
+            if self.panel_visible(forward_order[at]) {
+                return forward_order[at];
+            }
+        }
+        FocusedPanel::Graph
+    }
+
+    /// Focus the files pane, un-hiding it first when hidden (#116): every
+    /// caller expresses explicit intent to work with files (conflict guidance,
+    /// "go to files", returning from the diff viewer), so the pane must
+    /// actually appear — a hidden pane silently holding focus would strand
+    /// input.
+    pub(crate) fn focus_files_pane(&mut self) {
+        if self.hide_files_pane {
+            self.hide_files_pane = false;
+            self.save_ui_state();
+        }
+        self.focused_panel = FocusedPanel::Files;
+    }
+
+    /// Toggle the files pane's visibility (persisted, #116). Hiding the pane
+    /// that holds focus moves focus to the graph.
+    pub(crate) fn toggle_files_pane(&mut self) {
+        self.hide_files_pane = !self.hide_files_pane;
+        if !self.panel_visible(self.focused_panel) {
+            self.focused_panel = FocusedPanel::Graph;
+        }
+        self.save_ui_state();
+        let state = if self.hide_files_pane { "hidden" } else { "shown" };
+        self.toast(crate::toast::ToastKind::Info, format!("Files pane {state}"));
+    }
+
+    /// Toggle the commit-detail pane's visibility (persisted, #116). Hiding the
+    /// pane that holds focus moves focus to the graph.
+    pub(crate) fn toggle_commit_pane(&mut self) {
+        self.hide_commit_pane = !self.hide_commit_pane;
+        if !self.panel_visible(self.focused_panel) {
+            self.editing_commit_message = false;
+            self.focused_panel = FocusedPanel::Graph;
+        }
+        self.save_ui_state();
+        let state = if self.hide_commit_pane { "hidden" } else { "shown" };
+        self.toast(crate::toast::ToastKind::Info, format!("Commit pane {state}"));
+    }
+
     pub(crate) fn toggle_remote_branches(&mut self) -> Result<()> {
         self.hide_remote_branches = !self.hide_remote_branches;
         self.save_ui_state();

--- a/src/config.rs
+++ b/src/config.rs
@@ -329,6 +329,11 @@ pub struct UiState {
     /// Hide stash entries (and any commits reachable only as stash parents) from
     /// the graph. Off by default (stashes shown), preserving historical behavior.
     pub hide_stashes: bool,
+    /// Hide the files pane entirely (#116); its space goes to the commit pane,
+    /// or to the graph when both detail panes are hidden. Off by default.
+    pub hide_files_pane: bool,
+    /// Hide the commit-detail pane entirely (#116). Off by default.
+    pub hide_commit_pane: bool,
     pub metadata_columns: MetadataColumns,
 }
 
@@ -345,6 +350,8 @@ impl Default for UiState {
             dim_merged_branches: true,
             files_group_by_folder: false,
             hide_stashes: false,
+            hide_files_pane: false,
+            hide_commit_pane: false,
             metadata_columns: MetadataColumns::default(),
         }
     }
@@ -567,6 +574,8 @@ mod tests {
             dim_merged_branches: false,
             files_group_by_folder: true,
             hide_stashes: false,
+            hide_files_pane: true,
+            hide_commit_pane: false,
             metadata_columns: MetadataColumns {
                 author: true,
                 hash: false,

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -210,6 +210,16 @@ fn map_normal_mode(
         if key.modifiers.contains(KeyModifiers::SHIFT) && key.code == KeyCode::Char('I') {
             return Some(Action::OpenIssueList);
         }
+
+        // Pane visibility (#116): Shift+F / Shift+C from any panel, so a pane
+        // can be brought back while focus sits elsewhere. Both letters are
+        // unbound in every Normal-mode panel scope.
+        if key.modifiers.contains(KeyModifiers::SHIFT) && key.code == KeyCode::Char('F') {
+            return Some(Action::ToggleFilesPane);
+        }
+        if key.modifiers.contains(KeyModifiers::SHIFT) && key.code == KeyCode::Char('C') {
+            return Some(Action::ToggleCommitPane);
+        }
     }
 
     // Panel navigation with left/right arrows and Tab (from any panel)

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -522,6 +522,20 @@ pub fn descriptors() -> Vec<SettingDescriptor> {
             side_panel_layout,
             side_panel_layout
         ),
+        state_bool!(
+            "Hide files pane",
+            Interface,
+            None,
+            hide_files_pane,
+            hide_files_pane
+        ),
+        state_bool!(
+            "Hide commit pane",
+            Interface,
+            None,
+            hide_commit_pane,
+            hide_commit_pane
+        ),
         SettingDescriptor {
             label: "Theme",
             group: Interface,
@@ -600,6 +614,8 @@ mod tests {
             dim_merged_branches: false,
             files_group_by_folder: true,
             hide_stashes: true,
+            hide_files_pane: true,
+            hide_commit_pane: true,
             metadata_columns: MetadataColumns {
                 author: false,
                 hash: false,

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -48,6 +48,7 @@ fn entries(is_uncommitted: bool) -> Vec<HelpEntry> {
         Row("↑ / ↓", "Move up/down"),
         Row("← / →", "Switch panels"),
         Row("Tab / Shift+Tab", "Switch panels (forward/back)"),
+        Row("Shift+F / Shift+C", "Show/hide the files / commit pane"),
         Row("Ctrl+d/u", "Page down/up"),
         Row("g / Home", "Go to top"),
         Row("Shift+G / End", "Go to bottom"),

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -258,10 +258,16 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
     let status_area = vertical[1];
 
     // Split main area: graph + detail. The graph gets `graph_split_ratio`%;
-    // the divider between them is drag-resizable.
+    // the divider between them is drag-resizable. With both detail panes
+    // hidden (#116) there is no detail area at all — the graph takes the full
+    // main area and the hidden panes get zero-size rects, which also removes
+    // them from mouse hit-testing (a zero-size Rect contains no point).
     let graph_ratio = app.graph_split_ratio;
     let detail_ratio = 100u16.saturating_sub(graph_ratio);
-    let (graph_area, detail_area) = if app.side_panel_layout {
+    let show_detail = !(app.hide_files_pane && app.hide_commit_pane);
+    let (graph_area, detail_area) = if !show_detail {
+        (main_area, Rect::default())
+    } else if app.side_panel_layout {
         // Side layout: detail on LEFT, graph on RIGHT.
         let h = Layout::default()
             .direction(Direction::Horizontal)
@@ -283,18 +289,24 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
         (v[0], v[1])
     };
 
-    // Split detail area into files pane + commit detail
-    let detail_direction = if detail_area.width <= 56 {
-        Direction::Vertical
+    // Split detail area into files pane + commit detail; a hidden pane (#116)
+    // cedes the whole detail area to the other.
+    let (files_area, commit_area) = if app.hide_files_pane {
+        (Rect::default(), detail_area)
+    } else if app.hide_commit_pane {
+        (detail_area, Rect::default())
     } else {
-        Direction::Horizontal
+        let detail_direction = if detail_area.width <= 56 {
+            Direction::Vertical
+        } else {
+            Direction::Horizontal
+        };
+        let detail_chunks = Layout::default()
+            .direction(detail_direction)
+            .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+            .split(detail_area);
+        (detail_chunks[0], detail_chunks[1])
     };
-    let detail_chunks = Layout::default()
-        .direction(detail_direction)
-        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
-        .split(detail_area);
-    let files_area = detail_chunks[0];
-    let commit_area = detail_chunks[1];
 
     // Record panel rects for mouse hit-testing.
     app.mouse_layout = crate::app::MouseLayout {
@@ -305,8 +317,14 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
         side_layout: app.side_panel_layout,
     };
 
-    // Pre-render pass: compute layout metrics that update App scroll state
-    let commit_lines = compute_commit_detail_layout(app, commit_area, &theme);
+    // Pre-render pass: compute layout metrics that update App scroll state.
+    // Skipped for a hidden commit pane (#116): the layout pass shells out for
+    // signature status and recomputes wrapped lines — work with no consumer.
+    let commit_lines = if commit_area.is_empty() {
+        Vec::new()
+    } else {
+        compute_commit_detail_layout(app, commit_area, &theme)
+    };
     stage!(app, "detail_layout");
 
     // Render widgets
@@ -455,18 +473,24 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
         }
     }
     stage!(app, "overlay");
-    let mut files_state = FilesPaneState {
-        selected: Some(app.file_selected_index()),
-        offset: 0,
-    };
-    frame.render_stateful_widget(FilesPaneWidget::new(app, &theme), files_area, &mut files_state);
-    // The widget windows around the selection; keep the resulting offset for
-    // mouse hit-testing.
-    app.files_view_offset = files_state.offset;
-    frame.render_widget(
-        CommitDetailWidget::new(app, commit_area, &theme, commit_lines),
-        commit_area,
-    );
+    // Hidden panes (#116) have zero-size rects — skip their widgets entirely
+    // (ratatui would draw nothing, but the widgets' constructors do real work).
+    if !files_area.is_empty() {
+        let mut files_state = FilesPaneState {
+            selected: Some(app.file_selected_index()),
+            offset: 0,
+        };
+        frame.render_stateful_widget(FilesPaneWidget::new(app, &theme), files_area, &mut files_state);
+        // The widget windows around the selection; keep the resulting offset for
+        // mouse hit-testing.
+        app.files_view_offset = files_state.offset;
+    }
+    if !commit_area.is_empty() {
+        frame.render_widget(
+            CommitDetailWidget::new(app, commit_area, &theme, commit_lines),
+            commit_area,
+        );
+    }
 
     // Scrollbars on the right border of each scrollable pane. Rendered after the
     // panes (and the pixel overlay) so the track sits on top of the border.

--- a/tests/app_behavior_test.rs
+++ b/tests/app_behavior_test.rs
@@ -2132,3 +2132,72 @@ fn startup_defers_merged_classification_to_the_background() {
         app.merged.branches
     );
 }
+
+// ── Pane visibility (#116) ──────────────────────────────────────────
+
+#[test]
+fn hiding_the_focused_pane_moves_focus_to_the_graph() {
+    let (_td, repo) = init_repo();
+    commit_file(repo.repo(), "a.txt", "a", "first");
+    let mut app = make_app(repo);
+
+    app.focused_panel = FocusedPanel::Files;
+    app.handle_action(Action::ToggleFilesPane).unwrap();
+    assert!(app.hide_files_pane);
+    assert_eq!(
+        app.focused_panel,
+        FocusedPanel::Graph,
+        "focus must never remain on a hidden pane"
+    );
+    assert!(
+        app.toasts.visible().iter().any(|t| t.text.contains("Files pane hidden")),
+        "the toggle reports its new state"
+    );
+
+    // Toggling again brings the pane back (focus stays where it is).
+    app.handle_action(Action::ToggleFilesPane).unwrap();
+    assert!(!app.hide_files_pane);
+    assert!(app.toasts.visible().iter().any(|t| t.text.contains("Files pane shown")));
+}
+
+#[test]
+fn hiding_the_commit_pane_stops_commit_editing() {
+    let (_td, repo) = init_repo();
+    commit_file(repo.repo(), "a.txt", "a", "first");
+    let mut app = make_app(repo);
+
+    app.focused_panel = FocusedPanel::CommitDetail;
+    app.editing_commit_message = true;
+    app.handle_action(Action::ToggleCommitPane).unwrap();
+    assert!(app.hide_commit_pane);
+    assert_eq!(app.focused_panel, FocusedPanel::Graph);
+    assert!(
+        !app.editing_commit_message,
+        "a hidden editor must not keep capturing keystrokes"
+    );
+}
+
+#[test]
+fn panel_cycling_skips_hidden_panes() {
+    let (_td, repo) = init_repo();
+    commit_file(repo.repo(), "a.txt", "a", "first");
+    let mut app = make_app(repo);
+
+    // Files hidden: Graph → CommitDetail → Graph in both directions.
+    app.handle_action(Action::ToggleFilesPane).unwrap();
+    assert_eq!(app.focused_panel, FocusedPanel::Graph);
+    app.handle_action(Action::PanelRight).unwrap();
+    assert_eq!(app.focused_panel, FocusedPanel::CommitDetail, "skips hidden Files");
+    app.handle_action(Action::PanelRight).unwrap();
+    assert_eq!(app.focused_panel, FocusedPanel::Graph);
+    app.handle_action(Action::PanelLeft).unwrap();
+    assert_eq!(app.focused_panel, FocusedPanel::CommitDetail);
+
+    // Both hidden: cycling stays on the graph.
+    app.handle_action(Action::ToggleCommitPane).unwrap();
+    assert_eq!(app.focused_panel, FocusedPanel::Graph);
+    app.handle_action(Action::PanelRight).unwrap();
+    assert_eq!(app.focused_panel, FocusedPanel::Graph, "graph is the only visible panel");
+    app.handle_action(Action::PanelLeft).unwrap();
+    assert_eq!(app.focused_panel, FocusedPanel::Graph);
+}


### PR DESCRIPTION
Adds "straight up hide the commit pane / files pane" (#116):

- **Toggles**: `Shift+F` (files) / `Shift+C` (commit detail), bound in the shared any-panel section of Normal mode (suppressed while a text filter captures input); also two persisted Interface settings ("Hide files pane" / "Hide commit pane") in the settings menu, stored in `state.toml`.
- **Layout**: one hidden pane cedes the whole detail area to the other; both hidden removes the detail area entirely and the graph takes the full main area. Hidden panes get `Rect::default()` — a zero-size rect contains no point, so mouse hit-testing excludes them with no per-handler guards, and their widgets/scrollbars/commit-layout pass are skipped.
- **Focus invariant**: focus never lands on a hidden pane. Cycling (`Tab`/arrows) skips hidden panes; hiding the focused pane moves focus to the graph (and stops commit-message editing); startup focus respects the flags; conflict guidance, "go to files", and diff/history-viewer exits go through `focus_files_pane()`, which un-hides the pane first — explicit intent to see files beats the hide.
- Help popup documents the keys.

Tests: toggle moves focus + toasts, hidden editor stops capturing, cycling skips hidden panes (single and both), conflict flow un-hides, settings lens roundtrip covers the new `UiState` fields. Verified live via the debug server: baseline 3-pane dump → `Shift+F` → commit pane full-width + toast → `Shift+C` → full-screen graph, `Tab` stays on graph → restore → `state.toml` carries both keys → clean exit.

Closes #116.

🤖 Generated with [Claude Code](https://claude.com/claude-code)