### PR TITLE
Signature line removal, selected-commit undim, transitive merged classification

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -373,8 +373,13 @@ work that reached the trunk only through a chain (a stacked PR squashed into
 its parent branch, a sub-branch folded into a feature before the feature was
 squashed): no direct trunk signal exists for those, since a squash shares no
 commits. The trunk first-parent "behind" guard stays trunk-only on purpose —
-an old pointer into a *merged* branch's line is landed work and classifies
-via ancestry, unlike a pointer into a live trunk line. `--explain-merged`
+an old pointer into a *merged* branch's line is a dead pointer into an
+abandoned line and classifies via ancestry, unlike a pointer into a live
+trunk line. (Caveat: if a later commit on the merged branch superseded the
+pointed-at tree, that intermediate tree never literally landed on trunk —
+the pointer still classifies. Accepted: such pointers are stale leftovers,
+and the classification self-heals the moment the branch gets a new commit.)
+`--explain-merged`
 reports transitively-classified branches in a dedicated section naming the
 merged branch they landed through.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -365,6 +365,28 @@ display, fuzzy filtering) stays unit-testable without a TUI.
   branch-name reuse, and against a conflict-resolved landing being over-claimed
   locally).
 
+**Transitive closure** (2026-07-22): classification iterates to a fixed point
+(`classify_merged_branches_with_targets`) — after each pass, the tips of
+newly-classified branches join the tested tip set and the still-unclassified
+branches are re-tested, until a pass classifies nothing new. This catches
+work that reached the trunk only through a chain (a stacked PR squashed into
+its parent branch, a sub-branch folded into a feature before the feature was
+squashed): no direct trunk signal exists for those, since a squash shares no
+commits. The trunk first-parent "behind" guard stays trunk-only on purpose —
+an old pointer into a *merged* branch's line is landed work and classifies
+via ancestry, unlike a pointer into a live trunk line. `--explain-merged`
+reports transitively-classified branches in a dedicated section naming the
+merged branch they landed through.
+
+**Selection exemption** (2026-07-22): the merged-lane *dim* never applies to
+the commit under the cursor — `resolve_row_model` drops the merged-lane mute
+on the selected row (chips included), and both stroke renderers exempt any
+edge touching the selected commit's oid (`edge_touches_merged`'s `exempt`
+parameter, threaded as `RowRenderCtx::merged_exempt` / the pixel dim core's
+`merged_exempt`). Rationale: the widget-level `selection_style` only
+subtracts the DIM bit, so without this the selected row kept its muted
+foreground and dimmed strokes — inspecting a merged commit read greyed-out.
+
 **Async infrastructure** (`src/merged_branch_fetch.rs`):
 - The merged-PR-branch poll (`gh pr list --state merged`, 10s timeout, 300s
   interval) is an `IntervalFetch<HashSet<String>>` (see *Async Worker Shapes*

--- a/docs/vscode-parity.md
+++ b/docs/vscode-parity.md
@@ -61,9 +61,6 @@ files pane.)
 - **Per-file history** — files pane `h` lists commits that touched the selected
   path via `git log --follow` (rename-aware, capped at 200) in a picker; `Enter`
   opens that commit's diff for the file, `Esc` returns.
-- **Signature status** — commit detail shows a `Sig:` line from `git log -1
-  --format=%G?`, memoized per OID (`sig_status_cache`). Unsigned commits render
-  subtly; valid/bad signatures stand out.
 
 ## Notable full-parity areas
 

--- a/src/app/compare_actions.rs
+++ b/src/app/compare_actions.rs
@@ -1,7 +1,6 @@
-//! Two-commit comparison ("mark for compare") and commit signature status.
+//! Two-commit comparison ("mark for compare").
 
 use super::*;
-use crate::git::commit_signature_status;
 
 impl App {
     /// The OID of the selected graph node's commit, if it has one (excludes the
@@ -105,16 +104,5 @@ impl App {
             }
             Err(_) => (short_hash(oid), String::new()),
         }
-    }
-
-    /// Memoized GPG signature status (`%G?` code) for a commit. Commits are
-    /// immutable, so a value is cached forever once computed.
-    pub(crate) fn load_signature_status(&mut self, oid: Oid) -> char {
-        if let Some(&code) = self.sig_status_cache.get(&oid) {
-            return code;
-        }
-        let code = commit_signature_status(&self.repo_path, oid).unwrap_or('N');
-        self.sig_status_cache.insert(oid, code);
-        code
     }
 }

--- a/src/app/init.rs
+++ b/src/app/init.rs
@@ -226,7 +226,6 @@ impl App {
             diff_cache: DiffCache::new(),
             compare_marked: None,
             compare_range: None,
-            sig_status_cache: std::collections::HashMap::new(),
             should_quit: false,
             pending_refresh: false,
             diff_viewport_height: 40,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -973,10 +973,6 @@ pub struct App {
     pub compare_marked: Option<Oid>,
     pub compare_range: Option<(Oid, Oid)>,
 
-    // Per-OID GPG signature status cache (%G? code). Commits are immutable so
-    // this never needs invalidation; populated lazily on commit-detail render.
-    pub sig_status_cache: std::collections::HashMap<Oid, char>,
-
     // Flags
     pub should_quit: bool,
     pub pending_refresh: bool,

--- a/src/git/graph.rs
+++ b/src/git/graph.rs
@@ -1618,16 +1618,22 @@ pub fn merged_lane_oids(commits: &[CommitInfo], live_tips: &[Oid]) -> HashSet<Oi
 /// Whether a single `(child, parent)` edge touches a dimmed (merged-lane)
 /// commit: either endpoint is in `merged`. An edge to/from a vanishing commit
 /// is exactly a stroke hide-merged would remove, so this is what the merged-lane
-/// dim (issue #108) fades. `None` (no edge) never touches.
-pub fn edge_touches_merged(edge: Option<CellEdge>, merged: &HashSet<Oid>) -> bool {
-    edge.is_some_and(|(child, parent)| merged.contains(&child) || merged.contains(&parent))
+/// dim (issue #108) fades. `None` (no edge) never touches. An edge touching
+/// `exempt` — the selected commit — never counts: the commit under the cursor
+/// keeps its dot and its own strokes live even on a merged lane, so selecting
+/// a dimmed commit un-dims what the user is inspecting.
+pub fn edge_touches_merged(edge: Option<CellEdge>, merged: &HashSet<Oid>, exempt: Option<Oid>) -> bool {
+    edge.is_some_and(|(child, parent)| {
+        !exempt.is_some_and(|e| e == child || e == parent)
+            && (merged.contains(&child) || merged.contains(&parent))
+    })
 }
 
 /// Whether a cell (by its `(primary, secondary)` edges) touches a merged-lane
 /// commit. Either edge counts — the Unicode text path dims the whole glyph;
 /// the pixel path fades each edge independently (see `apply_merged_lane_dim`).
-pub fn cell_touches_merged(oids: CellOids, merged: &HashSet<Oid>) -> bool {
-    edge_touches_merged(oids.0, merged) || edge_touches_merged(oids.1, merged)
+pub fn cell_touches_merged(oids: CellOids, merged: &HashSet<Oid>, exempt: Option<Oid>) -> bool {
+    edge_touches_merged(oids.0, merged, exempt) || edge_touches_merged(oids.1, merged, exempt)
 }
 
 #[cfg(test)]
@@ -2857,12 +2863,25 @@ mod tests {
     fn edge_and_cell_touch_merged_on_either_endpoint() {
         let merged: HashSet<Oid> = [oid(4)].into_iter().collect();
         // Either endpoint in the set makes the edge touch.
-        assert!(edge_touches_merged(Some((oid(4), oid(3))), &merged));
-        assert!(edge_touches_merged(Some((oid(1), oid(4))), &merged));
-        assert!(!edge_touches_merged(Some((oid(1), oid(3))), &merged));
-        assert!(!edge_touches_merged(None, &merged));
+        assert!(edge_touches_merged(Some((oid(4), oid(3))), &merged, None));
+        assert!(edge_touches_merged(Some((oid(1), oid(4))), &merged, None));
+        assert!(!edge_touches_merged(Some((oid(1), oid(3))), &merged, None));
+        assert!(!edge_touches_merged(None, &merged, None));
         // A cell touches when either of its two edges does.
-        assert!(cell_touches_merged((None, Some((oid(4), oid(3)))), &merged));
-        assert!(!cell_touches_merged((Some((oid(1), oid(2))), None), &merged));
+        assert!(cell_touches_merged((None, Some((oid(4), oid(3)))), &merged, None));
+        assert!(!cell_touches_merged((Some((oid(1), oid(2))), None), &merged, None));
+    }
+
+    #[test]
+    fn selected_commit_exempts_its_edges_from_merged_touch() {
+        // An edge touching the exempt (selected) commit never reads merged —
+        // even when its other endpoint is also in the set — so the selected
+        // dot and its own strokes stay live; unrelated edges still dim.
+        let merged: HashSet<Oid> = [oid(4), oid(5)].into_iter().collect();
+        assert!(!edge_touches_merged(Some((oid(4), oid(3))), &merged, Some(oid(4))));
+        assert!(!edge_touches_merged(Some((oid(4), oid(5))), &merged, Some(oid(4))));
+        assert!(!edge_touches_merged(Some((oid(1), oid(4))), &merged, Some(oid(4))));
+        assert!(edge_touches_merged(Some((oid(5), oid(3))), &merged, Some(oid(4))));
+        assert!(!cell_touches_merged((Some((oid(4), oid(3))), None), &merged, Some(oid(4))));
     }
 }

--- a/src/git/merged.rs
+++ b/src/git/merged.rs
@@ -14,6 +14,13 @@
 //!    idea applied to the whole branch rather than commit-by-commit, which is
 //!    what catches a squash. See issue #60.
 //!
+//! Classification is **transitive**: a branch merged into an already-merged
+//! branch (a stacked PR, a sub-branch folded into its feature before the
+//! feature landed) is itself merged — its work reached the trunk through the
+//! chain even when no direct trunk signal exists. The classifier iterates to a
+//! fixed point, treating each classified branch's tip as an additional landed
+//! tip (see [`classify_merged_branches_with_targets`]).
+//!
 //! Pure functions over a `git2::Repository`; no UI, no caching (the caller
 //! memoises). The GitHub-PR signal (a branch whose head matches a *merged* PR)
 //! is layered on top by the caller — this module is the local-git fallback that
@@ -365,8 +372,11 @@ fn gh_key(b: &BranchInfo) -> &str {
 /// useful. Nor any tip that sits ON a trunk line's first-parent chain: that is a
 /// branch which is merely *behind*, not merged (#112, [`trunk_first_parent_line`]).
 ///
-/// `base_tips` are the trunk tips to test against (local trunk plus, when it
-/// lags, its `origin/…` counterpart — see [`base_tips`]). Merged when **any** of:
+/// `base_tips` are the tips to test against: the trunk tips (local trunk plus,
+/// when it lags, its `origin/…` counterpart — see [`base_tips`]) and, in the
+/// later rounds of [`classify_merged_branches_with_targets`]'s fixed point, the
+/// tips of branches already classified merged (transitive merges: landing in a
+/// landed branch is landing). Merged when **any** of:
 ///  - ancestry: the branch tip is contained in a base (merge / fast-forward);
 ///  - squash: the branch's cumulative diff matches a squashed commit on a base;
 ///  - GitHub says a PR with this head branch merged **and** the branch carries no
@@ -490,6 +500,10 @@ pub fn explain_classification(
     let _ = writeln!(out, "gh merged-PR heads known: {}", gh_merged.len());
 
     let base_short = base.name.split_once('/').map_or(base.name.as_str(), |(_, rest)| rest);
+    // Branches the direct (trunk-tips-only) pass below classifies, so the
+    // transitive section at the end can report exactly the ones only the fixed
+    // point catches.
+    let mut direct_merged: HashSet<&str> = HashSet::new();
     for b in branches {
         let kind = if b.is_remote { "remote" } else { "local " };
         let _ = writeln!(out, "\n{kind} {} @ {}", b.name, short(b.tip_oid));
@@ -574,7 +588,39 @@ pub fn explain_classification(
                 let _ = writeln!(out, "  gh signal present but content NOT contained (conflict-resolved landing, or novel work)");
             }
         }
+        if verdict.is_some() {
+            direct_merged.insert(&b.name);
+        }
         let _ = writeln!(out, "  => {}", verdict.unwrap_or_else(|| "visible (not classified merged)".into()));
+    }
+
+    // The real classifier iterates to a fixed point, re-testing unclassified
+    // branches against the tips of branches already classified (transitive
+    // merges). Run it and report what only that pass caught, naming a merged
+    // branch whose tip carries the landing when one is identifiable.
+    let final_merged = classify_merged_branches(repo, branches, base.tip_oid, &base.name, gh_merged);
+    let transitive: Vec<&BranchInfo> = branches
+        .iter()
+        .filter(|b| final_merged.contains(&b.name) && !direct_merged.contains(b.name.as_str()))
+        .collect();
+    if !transitive.is_empty() {
+        let _ = writeln!(out, "\ntransitive pass (merged into an already-merged branch):");
+        for b in transitive {
+            let via = branches.iter().find(|a| {
+                a.name != b.name
+                    && a.tip_oid != b.tip_oid
+                    && final_merged.contains(&a.name)
+                    && (is_ancestor_merged(repo, b.tip_oid, a.tip_oid)
+                        || squash_merge_target(repo, b.tip_oid, a.tip_oid).is_some())
+            });
+            let _ = writeln!(
+                out,
+                "  {} => MERGED transitively{}",
+                b.name,
+                via.map(|a| format!(" (landed in merged branch {} @ {})", a.name, short(a.tip_oid)))
+                    .unwrap_or_default()
+            );
+        }
     }
     out
 }
@@ -584,6 +630,8 @@ pub fn explain_classification(
 /// merged-PR signal (cross-checked locally via [`branch_content_in_base`]).
 /// Remote refs are included because a GitHub squash-merge often leaves the
 /// *remote* branch as the surviving ref (issue #100). See [`branch_is_merged`].
+/// Transitive: a branch merged into a branch in the set is in the set (see
+/// [`classify_merged_branches_with_targets`]).
 ///
 /// Intended to run **off the UI thread** (one ancestry query plus a bounded
 /// patch-id scan per candidate branch); the result is delivered back and applied
@@ -618,23 +666,51 @@ pub fn classify_merged_branches_with_targets(
 ) -> (HashSet<String>, HashMap<String, Oid>) {
     // Measure against the local trunk *and* its remote-tracking tip when the
     // local one lags (the post-fetch, pre-pull state) — see [`base_tips`].
-    let tips = base_tips(branches, base_tip, base_name);
+    let mut tips = base_tips(branches, base_tip, base_name);
     let trunk_line = trunk_first_parent_line(repo, &tips);
     let mut merged = HashSet::new();
     let mut targets = HashMap::new();
-    for b in branches {
-        if !branch_is_merged(repo, b, branches, &tips, &trunk_line, base_name, gh_merged) {
-            continue;
+    // Fixed point over "merged into a merged branch": work that landed in an
+    // already-merged branch has itself landed (a stacked PR squashed into its
+    // parent branch, a sub-branch merged into a feature before the feature was
+    // squashed to trunk). Each round tests the still-unclassified branches
+    // against the trunk tips PLUS every tip classified so far, and stops when a
+    // round classifies nothing new — chains resolve one level per round, so the
+    // round count is bounded by the deepest merge chain (≤ #branches).
+    // `trunk_line` stays trunk-only on purpose: an old pointer into a *merged*
+    // branch's own line is dead work that landed, not a live "behind" trunk
+    // state, so it classifies via ancestry instead of being refused.
+    loop {
+        let mut grew = false;
+        for b in branches {
+            if merged.contains(&b.name)
+                || !branch_is_merged(repo, b, branches, &tips, &trunk_line, base_name, gh_merged)
+            {
+                continue;
+            }
+            merged.insert(b.name.clone());
+            // Record the squash landing commit when one is nameable. Purely additive
+            // over the yes/no classification above — a branch with no squash target
+            // (ancestry merge, or a GitHub-only content match) stays out of the map.
+            if let Some(target) = tips
+                .iter()
+                .find_map(|&t| squash_merge_target(repo, b.tip_oid, t))
+            {
+                targets.insert(b.name.clone(), target);
+            }
+            grew = true;
         }
-        merged.insert(b.name.clone());
-        // Record the squash landing commit when one is nameable. Purely additive
-        // over the yes/no classification above — a branch with no squash target
-        // (ancestry merge, or a GitHub-only content match) stays out of the map.
-        if let Some(target) = tips
-            .iter()
-            .find_map(|&t| squash_merge_target(repo, b.tip_oid, t))
-        {
-            targets.insert(b.name.clone(), target);
+        if !grew {
+            break;
+        }
+        // Newly-merged tips become additional "landed" tips for the next round.
+        // Extended only BETWEEN rounds, so within a round every branch is judged
+        // against the same tip set (same-tip twins classify together before the
+        // tip-equality guard in `branch_is_merged` could refuse the second one).
+        for b in branches {
+            if merged.contains(&b.name) && !tips.contains(&b.tip_oid) {
+                tips.push(b.tip_oid);
+            }
         }
     }
     (merged, targets)
@@ -1931,5 +2007,148 @@ mod tests {
         let branches = vec![local("dev", o(7), false), remote("origin/dev", o(7))];
         assert_eq!(base_ref_tips(&branches, "dev"), vec![o(7)]);
         assert!(base_ref_tips(&[], "dev").is_empty());
+    }
+
+    // ── transitive classification: merged into a merged branch ───────
+
+    #[test]
+    fn branch_merged_into_a_squash_merged_branch_is_classified_transitively() {
+        // sub was merge-committed into feature, then feature was SQUASHED to
+        // main — so no commit of sub is an ancestor of the trunk, and sub's own
+        // cumulative diff (+sub.txt) matches no single trunk commit (the squash
+        // carries feature's whole diff). Only testing sub against the tip of
+        // the already-classified feature branch catches it.
+        let dir = tempfile::tempdir().unwrap();
+        let repo = Repository::init(dir.path()).unwrap();
+        let a = commit(&repo, "refs/heads/main", 1000, &[], &[("base.txt", "base")]);
+        let b = commit(&repo, "refs/heads/main", 2000, &[a], &[("base.txt", "base"), ("main.txt", "main")]);
+        let s1 = commit(&repo, "refs/heads/sub", 2100, &[a], &[("base.txt", "base"), ("sub.txt", "s")]);
+        let f1 = commit(&repo, "refs/heads/feature", 2200, &[a], &[("base.txt", "base"), ("feat.txt", "f")]);
+        let f2 = commit(
+            &repo,
+            "refs/heads/feature",
+            2300,
+            &[f1, s1],
+            &[("base.txt", "base"), ("feat.txt", "f"), ("sub.txt", "s")],
+        );
+        let sq = commit(
+            &repo,
+            "refs/heads/main",
+            3000,
+            &[b],
+            &[("base.txt", "base"), ("main.txt", "main"), ("feat.txt", "f"), ("sub.txt", "s")],
+        );
+
+        let branches = vec![
+            local("main", sq, true),
+            local("feature", f2, false),
+            local("sub", s1, false),
+        ];
+        let merged = merged_local_branches(&repo, &branches, sq, "main");
+        assert!(merged.contains("feature"), "feature squashed to trunk");
+        assert!(merged.contains("sub"), "sub landed through feature (transitive)");
+        assert!(!merged.contains("main"));
+    }
+
+    #[test]
+    fn chain_of_squashes_is_classified_recursively() {
+        // c squashed into bb, bb squashed into aa, aa squashed into main: each
+        // level shares no commit with the level above, so every branch except
+        // aa needs the fixed point — bb resolves in round two against aa's tip,
+        // c in round three against bb's tip.
+        let dir = tempfile::tempdir().unwrap();
+        let repo = Repository::init(dir.path()).unwrap();
+        let base = ("base.txt", "base");
+        let a = commit(&repo, "refs/heads/main", 1000, &[], &[base]);
+        let b = commit(&repo, "refs/heads/main", 2000, &[a], &[base, ("main.txt", "m")]);
+        let c1 = commit(&repo, "refs/heads/c", 2100, &[a], &[base, ("c.txt", "c")]);
+        let b1 = commit(&repo, "refs/heads/bb", 2200, &[a], &[base, ("bb.txt", "b")]);
+        let b2 = commit(&repo, "refs/heads/bb", 2300, &[b1], &[base, ("bb.txt", "b"), ("c.txt", "c")]);
+        let a1 = commit(&repo, "refs/heads/aa", 2400, &[a], &[base, ("aa.txt", "a")]);
+        let a2 = commit(
+            &repo,
+            "refs/heads/aa",
+            2500,
+            &[a1],
+            &[base, ("aa.txt", "a"), ("bb.txt", "b"), ("c.txt", "c")],
+        );
+        let sq = commit(
+            &repo,
+            "refs/heads/main",
+            3000,
+            &[b],
+            &[base, ("main.txt", "m"), ("aa.txt", "a"), ("bb.txt", "b"), ("c.txt", "c")],
+        );
+
+        let branches = vec![
+            local("main", sq, true),
+            local("aa", a2, false),
+            local("bb", b2, false),
+            local("c", c1, false),
+        ];
+        let merged = merged_local_branches(&repo, &branches, sq, "main");
+        assert!(merged.contains("aa"), "direct squash to trunk");
+        assert!(merged.contains("bb"), "squashed into merged aa");
+        assert!(merged.contains("c"), "squashed into transitively-merged bb");
+        assert!(!merged.contains("main"));
+    }
+
+    #[test]
+    fn branch_merged_into_an_unmerged_branch_stays_visible() {
+        // sub landed in feature, but feature itself never landed on main — no
+        // link to the trunk exists, so the fixed point must classify neither.
+        let dir = tempfile::tempdir().unwrap();
+        let repo = Repository::init(dir.path()).unwrap();
+        let a = commit(&repo, "refs/heads/main", 1000, &[], &[("base.txt", "base")]);
+        let b = commit(&repo, "refs/heads/main", 2000, &[a], &[("base.txt", "base"), ("main.txt", "m")]);
+        let s1 = commit(&repo, "refs/heads/sub", 2100, &[a], &[("base.txt", "base"), ("sub.txt", "s")]);
+        let f1 = commit(&repo, "refs/heads/feature", 2200, &[a], &[("base.txt", "base"), ("feat.txt", "f")]);
+        let f2 = commit(
+            &repo,
+            "refs/heads/feature",
+            2300,
+            &[f1, s1],
+            &[("base.txt", "base"), ("feat.txt", "f"), ("sub.txt", "s")],
+        );
+
+        let branches = vec![
+            local("main", b, true),
+            local("feature", f2, false),
+            local("sub", s1, false),
+        ];
+        let merged = merged_local_branches(&repo, &branches, b, "main");
+        assert!(merged.is_empty(), "no branch reached the trunk: {merged:?}");
+    }
+
+    #[test]
+    fn old_pointer_into_a_merged_branchs_line_is_classified() {
+        // backup points at an intermediate commit of a squash-merged branch.
+        // On the TRUNK an on-line pointer is "behind, not merged" (#112) —
+        // that guard protects live lines. A merged branch's line is dead,
+        // landed work, so an old pointer into it has landed too: classified
+        // via ancestry against the merged branch's tip in round two.
+        let dir = tempfile::tempdir().unwrap();
+        let repo = Repository::init(dir.path()).unwrap();
+        let a = commit(&repo, "refs/heads/main", 1000, &[], &[("base.txt", "base")]);
+        let b = commit(&repo, "refs/heads/main", 2000, &[a], &[("base.txt", "base"), ("main.txt", "m")]);
+        let f1 = commit(&repo, "refs/heads/feature", 2100, &[a], &[("base.txt", "base"), ("feat.txt", "one")]);
+        let f2 = commit(&repo, "refs/heads/feature", 2200, &[f1], &[("base.txt", "base"), ("feat.txt", "two")]);
+        repo.reference("refs/heads/backup", f1, true, "backup").unwrap();
+        let sq = commit(
+            &repo,
+            "refs/heads/main",
+            3000,
+            &[b],
+            &[("base.txt", "base"), ("main.txt", "m"), ("feat.txt", "two")],
+        );
+
+        let branches = vec![
+            local("main", sq, true),
+            local("feature", f2, false),
+            local("backup", f1, false),
+        ];
+        let merged = merged_local_branches(&repo, &branches, sq, "main");
+        assert!(merged.contains("feature"));
+        assert!(merged.contains("backup"), "old state of a landed line is landed");
     }
 }

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -18,7 +18,7 @@ pub use diff::{
     CommitDiffInfo, DiffHunkContent, DiffLineContent, DiffLineOrigin, FileChangeKind,
     FileDiffContent, FileDiffInfo, StageStatus,
 };
-pub use operations::{commit_signature_status, file_history, signature_status_label};
+pub use operations::file_history;
 pub use patch::{extract_hunk_from_working_tree, render_hunk_patch, HunkPatch, PatchLine, PatchLineKind};
 pub use extensions::configure_git_extensions;
 pub use graph::build_graph;

--- a/src/git/operations.rs
+++ b/src/git/operations.rs
@@ -1249,37 +1249,11 @@ pub fn file_history(repo_path: &str, path: &str, limit: usize) -> Result<Vec<Oid
     Ok(oids)
 }
 
-/// Query the GPG signature status of a commit via `git log -1 --format=%G?`.
-/// Returns the raw `%G?` status code (one of G/B/U/X/Y/R/E/N), defaulting to
-/// `'N'` (unsigned) when git prints nothing.
-pub fn commit_signature_status(repo_path: &str, oid: Oid) -> Result<char> {
-    let oid_str = oid.to_string();
-    let output = run_git(repo_path, &["log", "-1", "--format=%G?", &oid_str])?;
-    let text = String::from_utf8_lossy(&output.stdout);
-    Ok(text.trim().chars().next().unwrap_or('N'))
-}
-
-/// Map a `%G?` signature status code to a short human-readable label.
-/// Pure function (no I/O) — the display layer renders whatever this returns.
-pub fn signature_status_label(code: char) -> &'static str {
-    match code {
-        'G' => "signed (valid)",
-        'B' => "signed (BAD)",
-        'U' => "signed (valid, unknown trust)",
-        'X' => "signed (valid, expired)",
-        'Y' => "signed (expired key)",
-        'R' => "signed (revoked key)",
-        'E' => "signature unverifiable",
-        'N' => "unsigned",
-        _ => "unknown",
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::{
         extract_auth_url, humanize_git_error, is_dirty_worktree_pull_error,
-        is_divergent_pull_error, is_https_auth_failure, signature_status_label, url_host, AuthUrl,
+        is_divergent_pull_error, is_https_auth_failure, url_host, AuthUrl,
         OpOutcome, PullMode,
     };
 
@@ -1401,24 +1375,6 @@ mod tests {
         .contains("in progress"));
         // Unrecognized -> None (caller falls back to raw).
         assert_eq!(humanize_git_error("some unexpected failure"), None);
-    }
-
-    #[test]
-    fn signature_labels_cover_all_git_codes() {
-        assert_eq!(signature_status_label('G'), "signed (valid)");
-        assert_eq!(signature_status_label('B'), "signed (BAD)");
-        assert_eq!(signature_status_label('U'), "signed (valid, unknown trust)");
-        assert_eq!(signature_status_label('X'), "signed (valid, expired)");
-        assert_eq!(signature_status_label('Y'), "signed (expired key)");
-        assert_eq!(signature_status_label('R'), "signed (revoked key)");
-        assert_eq!(signature_status_label('E'), "signature unverifiable");
-        assert_eq!(signature_status_label('N'), "unsigned");
-    }
-
-    #[test]
-    fn signature_label_unknown_code_is_labelled_unknown() {
-        assert_eq!(signature_status_label('Z'), "unknown");
-        assert_eq!(signature_status_label(' '), "unknown");
     }
 
     use super::{fetch_all, fetch_remote};

--- a/src/ui/commit_detail.rs
+++ b/src/ui/commit_detail.rs
@@ -9,7 +9,6 @@ use ratatui::{
 };
 
 use crate::app::{App, FocusedPanel};
-use crate::git::signature_status_label;
 
 use super::{render_placeholder_block, theme::Theme, MIN_WIDGET_HEIGHT, MIN_WIDGET_WIDTH};
 
@@ -30,22 +29,6 @@ pub fn compute_commit_detail_layout<'a>(
     commit_area: Rect,
     theme: &'a Theme,
 ) -> Vec<Line<'a>> {
-    // Preload (and memoize) the signature status for the selected commit so the
-    // detail lines can render it without shelling out on the render path.
-    if app.compare_range.is_none() {
-        let sel_oid = app
-            .graph_nav
-            .graph_list_state
-            .selected()
-            .and_then(|i| app.graph_layout.nodes.get(i))
-            .filter(|n| !n.is_uncommitted && !n.is_stash)
-            .and_then(|n| n.commit.as_ref())
-            .map(|c| c.oid);
-        if let Some(oid) = sel_oid {
-            app.load_signature_status(oid);
-        }
-    }
-
     let (commit_lines, raw_editor_offset) =
         CommitDetailWidget::build_commit_lines_with_offset(app, theme);
 
@@ -259,26 +242,6 @@ impl<'a> CommitDetailWidget<'a> {
                 ),
             ]),
         ];
-
-        // Signature status line (from the memoized %G? cache). Stashes are
-        // never signed, so skip them. Unsigned commits render subtly (muted);
-        // a real signature stands out.
-        if !node.is_stash {
-            if let Some(&code) = app.sig_status_cache.get(&commit.oid) {
-                let (color, modifier) = match code {
-                    'N' => (theme.text_muted, Modifier::empty()),
-                    'G' | 'U' => (theme.author_color, Modifier::BOLD),
-                    _ => (theme.file_deleted, Modifier::BOLD),
-                };
-                lines.push(Line::from(vec![
-                    Span::styled("Sig:    ", theme.metadata_label_style()),
-                    Span::styled(
-                        signature_status_label(code).to_string(),
-                        Style::default().fg(color).add_modifier(modifier),
-                    ),
-                ]));
-            }
-        }
 
         lines.push(Line::from(""));
 

--- a/src/ui/graph_view/mod.rs
+++ b/src/ui/graph_view/mod.rs
@@ -73,6 +73,7 @@ pub(super) fn apply_merged_lane_dim(
     cells: &mut [crate::ui::graph_pixels::PixelCell],
     oids: &[crate::git::graph::CellOids],
     merged: &HashSet<git2::Oid>,
+    exempt: Option<git2::Oid>,
 ) {
     use crate::git::graph::edge_touches_merged;
     use crate::ui::graph_pixels::CellShape;
@@ -81,14 +82,16 @@ pub(super) fn apply_merged_lane_dim(
         if pc.shape == CellShape::HorizontalPipe {
             // Primary = the horizontal stroke (drawn in `secondary`); secondary =
             // the vertical lane crossed underneath (drawn in `color`).
-            if edge_touches_merged(primary, merged) {
+            if edge_touches_merged(primary, merged, exempt) {
                 pc.dim_secondary = true;
             }
-            if edge_touches_merged(secondary, merged) {
+            if edge_touches_merged(secondary, merged, exempt) {
                 pc.dim = true;
             }
         } else if matches!(pc.shape, CellShape::Commit { .. }) {
-            if edge_touches_merged(primary, merged) || edge_touches_merged(secondary, merged) {
+            if edge_touches_merged(primary, merged, exempt)
+                || edge_touches_merged(secondary, merged, exempt)
+            {
                 pc.dim = true;
                 pc.dim_secondary = true;
             }
@@ -99,14 +102,14 @@ pub(super) fn apply_merged_lane_dim(
             // dimmed lane no longer greys the live trunk it leaves from. A
             // fork-connector hub has no secondary edge — its trunk follows the
             // primary as before.
-            if edge_touches_merged(primary, merged) {
+            if edge_touches_merged(primary, merged, exempt) {
                 pc.dim_secondary = true;
             }
             let trunk = if secondary.is_some() { secondary } else { primary };
-            if edge_touches_merged(trunk, merged) {
+            if edge_touches_merged(trunk, merged, exempt) {
                 pc.dim = true;
             }
-        } else if edge_touches_merged(primary, merged) {
+        } else if edge_touches_merged(primary, merged, exempt) {
             pc.dim = true;
             pc.dim_secondary = true;
         }
@@ -143,6 +146,13 @@ impl<'a> GraphViewWidget<'a> {
         // without a rebuild — `None` = feature off, no row/cell is dimmed by it.
         let merged_lane_oids = (app.merged.dim && !app.merged.hide)
             .then_some(&app.merged.lane_oids);
+        // The selected commit is exempt from merged-lane dimming: the row under
+        // the cursor un-mutes and its own strokes stay live (its lane siblings
+        // keep dimming), so inspecting a merged commit never reads greyed-out.
+        let merged_exempt = app
+            .selected_commit_node()
+            .and_then(|n| n.commit.as_ref())
+            .map(|c| c.oid);
         // OIDs of base-update ("back-merge") commits (#55); a per-row O(1)
         // membership test, so the check stays inside the windowed render path.
         let base_update_merges = app.merged.base_update.value();
@@ -170,6 +180,7 @@ impl<'a> GraphViewWidget<'a> {
             merged_branches,
             merged_dim,
             merged_lane_oids,
+            merged_exempt,
             base_update_merges,
             metadata_columns,
             graph_width,
@@ -314,6 +325,7 @@ fn render_graph_line<'a>(
             ctx.trace,
             is_base_update,
             ctx.merged_lane_oids,
+            ctx.merged_exempt,
         );
     }
 
@@ -350,6 +362,7 @@ fn render_cells_unicode(
     trace: Option<&std::collections::HashMap<crate::git::graph::CellEdge, git2::Oid>>,
     force_dim: bool,
     merged_oids: Option<&HashSet<git2::Oid>>,
+    merged_exempt: Option<git2::Oid>,
 ) -> usize {
     // `budget` graph columns are available for glyphs; when truncating, one more
     // column holds the `…`.
@@ -373,9 +386,9 @@ fn render_cells_unicode(
             match node.cells.get(idx) {
                 Some(CellType::TeeRight(_) | CellType::TeeLeft(_)) => {
                     let trunk = if oids.1.is_some() { oids.1 } else { oids.0 };
-                    crate::git::graph::edge_touches_merged(trunk, m)
+                    crate::git::graph::edge_touches_merged(trunk, m, merged_exempt)
                 }
-                _ => crate::git::graph::cell_touches_merged(oids, m),
+                _ => crate::git::graph::cell_touches_merged(oids, m, merged_exempt),
             }
         };
         force_dim
@@ -533,6 +546,17 @@ mod tests {
     // assert on `RowModel` fields instead of scanning rendered spans. Mirrors the
     // is-base-update / is-merged-lane derivation `render_graph_line` performs.
     fn model_with_ctx(node: &GraphNode, ctx: &RowRenderCtx) -> RowModel {
+        model_with_ctx_flags(
+            node,
+            ctx,
+            RowFlags {
+                is_selected: false,
+                is_marked: false,
+            },
+        )
+    }
+
+    fn model_with_ctx_flags(node: &GraphNode, ctx: &RowRenderCtx, flags: RowFlags) -> RowModel {
         let commit = node.commit.as_ref().expect("commit node");
         let is_base_update = is_base_update_row(
             node,
@@ -543,17 +567,7 @@ mod tests {
             .commit
             .as_ref()
             .is_some_and(|c| ctx.merged_lane_oids.is_some_and(|s| s.contains(&c.oid)));
-        resolve_row_model(
-            node,
-            commit,
-            ctx,
-            RowFlags {
-                is_selected: false,
-                is_marked: false,
-            },
-            is_base_update,
-            is_merged_lane,
-        )
+        resolve_row_model(node, commit, ctx, flags, is_base_update, is_merged_lane)
     }
 
     // ── open-PR badge matching ───────────────────────────────────────
@@ -775,7 +789,7 @@ mod tests {
     fn render_cells(node: &GraphNode, cap: usize) -> String {
         let theme = Theme::dark();
         let mut spans: Vec<Span> = Vec::new();
-        let lw = render_cells_unicode(&mut spans, node, &theme, 0, cap, None, false, None);
+        let lw = render_cells_unicode(&mut spans, node, &theme, 0, cap, None, false, None, None);
         let text: String = spans.iter().map(|s| s.content.as_ref()).collect();
         // left_width is columns emitted (started at 0); it must equal the text's
         // display width.
@@ -914,6 +928,7 @@ mod tests {
             merged_branches: &HashSet::new(),
             merged_dim: true,
             merged_lane_oids: None,
+            merged_exempt: None,
             base_update_merges,
             metadata_columns: cols,
             graph_width: 4,
@@ -969,6 +984,7 @@ mod tests {
             merged_branches: &HashSet::new(),
             merged_dim: true,
             merged_lane_oids: None,
+            merged_exempt: None,
             base_update_merges,
             metadata_columns: cols,
             graph_width: 4,
@@ -1010,6 +1026,7 @@ mod tests {
             merged_branches,
             merged_dim,
             merged_lane_oids: None,
+            merged_exempt: None,
             base_update_merges: &HashSet::new(),
             metadata_columns: cols,
             graph_width: 4,
@@ -1120,6 +1137,7 @@ mod tests {
             merged_branches: &merged,
             merged_dim: true,
             merged_lane_oids: None,
+            merged_exempt: None,
             base_update_merges: &HashSet::new(),
             metadata_columns: merge_cols(true, false, false),
             graph_width: 4,
@@ -1141,6 +1159,69 @@ mod tests {
             style,
             super::badges::merged_style(&theme),
             "badge uses the merged style"
+        );
+    }
+
+    #[test]
+    fn merged_chip_keeps_full_hue_while_selected() {
+        // Selection exemption for chips: on the selected row a merged branch's
+        // chip skips the muted/dimmed treatment entirely (the widget-level
+        // `selection_style` would only strip DIM, leaving the muted hue), while
+        // the merged badge stays as the "this landed" indicator.
+        let node = branch_tip_node("ancestry commit", &["feature/ancestry-landed"]);
+        let merged: HashSet<String> = ["feature/ancestry-landed".to_string()].into_iter().collect();
+        let unmerged_model = model_row_with_merged(&node, &HashSet::new(), true);
+        let unmerged_chip = model_chip(&unmerged_model, "feature/ancestry-landed").clone();
+
+        let cols = MetadataColumns {
+            author: false,
+            hash: false,
+            date: false,
+            mute_merges: true,
+            mute_base_merges: false,
+            collapse_merges: false,
+            avatars: false,
+            pr_subjects: true,
+        };
+        let theme = Theme::dark();
+        let open_prs = HashMap::new();
+        let pr_ctx = PrContext::new(&open_prs);
+        let ctx = RowRenderCtx {
+            theme: &theme,
+            now: Local::now(),
+            pixel_mode: false,
+            remotes: &[],
+            open_prs: &open_prs,
+            pr_ctx: &pr_ctx,
+            merged_branches: &merged,
+            merged_dim: true,
+            merged_lane_oids: None,
+            merged_exempt: None,
+            base_update_merges: &HashSet::new(),
+            metadata_columns: cols,
+            graph_width: 4,
+            total_width: 200,
+            selected_branch_name: None,
+            trace: None,
+        };
+        let model = model_with_ctx_flags(
+            &node,
+            &ctx,
+            RowFlags {
+                is_selected: true,
+                is_marked: false,
+            },
+        );
+
+        let chip = model_chip(&model, "feature/ancestry-landed");
+        assert_eq!(
+            chip.style, unmerged_chip.style,
+            "selected merged chip styles exactly like an unmerged one"
+        );
+        assert_eq!(
+            model.merged_badge,
+            Some(merged_badge()),
+            "the merged badge still marks the landed branch while selected"
         );
     }
 
@@ -1237,6 +1318,7 @@ mod tests {
             merged_branches: &HashSet::new(),
             merged_dim: false,
             merged_lane_oids: lane_oids,
+            merged_exempt: None,
             base_update_merges: &HashSet::new(),
             metadata_columns: cols,
             graph_width: 4,
@@ -1273,6 +1355,70 @@ mod tests {
             model.author_style.fg,
             Some(theme.text_muted),
             "merged-lane author column greyed: {:?}",
+            model.author_style
+        );
+    }
+
+    #[test]
+    fn merged_lane_row_unmutes_while_selected() {
+        // The selection exemption: the very row that greys unselected renders
+        // live under the cursor — muted fg dropped, selection BOLD applied —
+        // because `selection_style` alone only strips the DIM bit and would
+        // leave the muted foreground in place.
+        let theme = Theme::dark();
+        let node = commit_node(7, "landed feature work", &[]);
+        let lane: HashSet<git2::Oid> = [oid(7)].into_iter().collect();
+        let cols = MetadataColumns {
+            author: true,
+            hash: true,
+            date: true,
+            mute_merges: false,
+            mute_base_merges: false,
+            collapse_merges: false,
+            avatars: false,
+            pr_subjects: true,
+        };
+        let open_prs = HashMap::new();
+        let pr_ctx = PrContext::new(&open_prs);
+        let ctx = RowRenderCtx {
+            theme: &theme,
+            now: Local::now(),
+            pixel_mode: false,
+            remotes: &[],
+            open_prs: &open_prs,
+            pr_ctx: &pr_ctx,
+            merged_branches: &HashSet::new(),
+            merged_dim: false,
+            merged_lane_oids: Some(&lane),
+            merged_exempt: Some(oid(7)),
+            base_update_merges: &HashSet::new(),
+            metadata_columns: cols,
+            graph_width: 4,
+            total_width: 200,
+            selected_branch_name: None,
+            trace: None,
+        };
+
+        let model = model_with_ctx_flags(
+            &node,
+            &ctx,
+            RowFlags {
+                is_selected: true,
+                is_marked: false,
+            },
+        );
+
+        assert!(!model.row_is_muted, "selected merged-lane row is not muted");
+        assert_eq!(model.msg_style.fg, None, "no muted fg while selected: {:?}", model.msg_style);
+        assert!(
+            model.msg_style.add_modifier.contains(Modifier::BOLD),
+            "selection bold applies: {:?}",
+            model.msg_style
+        );
+        assert_eq!(
+            model.author_style.fg,
+            Some(theme.author_color),
+            "author column keeps its own color while selected: {:?}",
             model.author_style
         );
     }
@@ -1346,7 +1492,7 @@ mod tests {
             Some((oid(2), oid(1))),
         )];
         let merged: HashSet<git2::Oid> = [oid(5)].into_iter().collect();
-        apply_merged_lane_dim(&mut cells, &oids, &merged);
+        apply_merged_lane_dim(&mut cells, &oids, &merged, None);
         assert!(cells[0].dim_secondary, "the arm into the dim lane fades");
         assert!(!cells[0].dim, "the live trunk through-line stays bright");
     }
@@ -1368,9 +1514,45 @@ mod tests {
         }];
         let oids = vec![(Some((oid(5), oid(1))), None)];
         let merged: HashSet<git2::Oid> = [oid(5)].into_iter().collect();
-        apply_merged_lane_dim(&mut cells, &oids, &merged);
+        apply_merged_lane_dim(&mut cells, &oids, &merged, None);
         assert!(cells[0].dim, "no lane edge: trunk follows the primary");
         assert!(cells[0].dim_secondary, "arm dims too");
+    }
+
+    #[test]
+    fn selected_commit_dot_stays_bright_in_pixel_merged_lane_dim() {
+        // Selection exemption in the pixel path: the selected commit's dot —
+        // even one whose edge runs to another merged commit — keeps full
+        // strength, while its merged lane sibling still dims.
+        use crate::ui::graph_pixels::CellShape;
+        let cell = |shape| crate::ui::graph_pixels::PixelCell {
+            shape,
+            color: [0, 255, 0],
+            secondary: [0, 255, 0],
+            dim: false,
+            dim_secondary: false,
+            curved_above: false,
+            curved_below: false,
+            spoke_on_dot: false,
+        };
+        let mut cells = vec![
+            cell(CellShape::Commit {
+                connect_up: true,
+                connect_down: true,
+                style: crate::ui::graph_pixels::CommitStyle::Normal,
+            }),
+            cell(CellShape::Pipe),
+        ];
+        // Dot's edge: selected commit oid(5) → merged parent oid(4); the pipe
+        // carries a purely merged edge.
+        let oids = vec![
+            (Some((oid(5), oid(4))), None),
+            (Some((oid(4), oid(3))), None),
+        ];
+        let merged: HashSet<git2::Oid> = [oid(3), oid(4), oid(5)].into_iter().collect();
+        apply_merged_lane_dim(&mut cells, &oids, &merged, Some(oid(5)));
+        assert!(!cells[0].dim, "selected dot exempt from merged-lane dim");
+        assert!(cells[1].dim, "the lane's other strokes still dim");
     }
 
     /// The full rendered text of a row (all spans concatenated).
@@ -1847,7 +2029,7 @@ mod tests {
             [((a, a), a)].into_iter().collect();
 
         let mut spans: Vec<Span> = Vec::new();
-        render_cells_unicode(&mut spans, &node, &theme, 0, 8, Some(&lit), false, None);
+        render_cells_unicode(&mut spans, &node, &theme, 0, 8, Some(&lit), false, None, None);
 
         let commit = spans.iter().find(|s| s.content.contains('●')).unwrap();
         let pipe = spans.iter().find(|s| s.content.contains('│')).unwrap();
@@ -1867,7 +2049,7 @@ mod tests {
         let mut node = node_with_cells(vec![CellType::Commit(0), CellType::Pipe(1)], false);
         node.cell_oids = vec![(Some((oid(1), oid(1))), None), (Some((oid(2), oid(2))), None)];
         let mut spans: Vec<Span> = Vec::new();
-        render_cells_unicode(&mut spans, &node, &theme, 0, 8, None, false, None);
+        render_cells_unicode(&mut spans, &node, &theme, 0, 8, None, false, None, None);
         assert!(spans
             .iter()
             .all(|s| !s.style.add_modifier.contains(Modifier::DIM)));
@@ -1886,7 +2068,7 @@ mod tests {
         let merged: HashSet<git2::Oid> = [m].into_iter().collect();
 
         let mut spans: Vec<Span> = Vec::new();
-        render_cells_unicode(&mut spans, &node, &theme, 0, 8, None, false, Some(&merged));
+        render_cells_unicode(&mut spans, &node, &theme, 0, 8, None, false, Some(&merged), None);
 
         let dot = spans.iter().find(|s| s.content.contains('●')).unwrap();
         let pipe = spans.iter().find(|s| s.content.contains('│')).unwrap();
@@ -1897,6 +2079,32 @@ mod tests {
         assert!(
             !pipe.style.add_modifier.contains(Modifier::DIM),
             "a trunk pipe with no merged endpoint stays bright"
+        );
+    }
+
+    #[test]
+    fn selected_commit_stays_bright_in_unicode_merged_lane_dim() {
+        // Selection exemption in the unicode path: with the merged dot's oid
+        // exempt, exactly the same row renders its dot at full strength while
+        // an unrelated merged cell still dims.
+        let theme = Theme::dark();
+        let (m, other) = (oid(4), oid(6));
+        let mut node = node_with_cells(vec![CellType::Commit(0), CellType::Pipe(1)], false);
+        node.cell_oids = vec![(Some((m, m)), None), (Some((other, other)), None)];
+        let merged: HashSet<git2::Oid> = [m, other].into_iter().collect();
+
+        let mut spans: Vec<Span> = Vec::new();
+        render_cells_unicode(&mut spans, &node, &theme, 0, 8, None, false, Some(&merged), Some(m));
+
+        let dot = spans.iter().find(|s| s.content.contains('●')).unwrap();
+        let pipe = spans.iter().find(|s| s.content.contains('│')).unwrap();
+        assert!(
+            !dot.style.add_modifier.contains(Modifier::DIM),
+            "selected merged commit dot exempt from the lane dim"
+        );
+        assert!(
+            pipe.style.add_modifier.contains(Modifier::DIM),
+            "other merged strokes on the row still dim"
         );
     }
 
@@ -1913,7 +2121,7 @@ mod tests {
         let merged: HashSet<git2::Oid> = [m].into_iter().collect();
 
         let mut spans: Vec<Span> = Vec::new();
-        render_cells_unicode(&mut spans, &node, &theme, 0, 8, Some(&lit), false, Some(&merged));
+        render_cells_unicode(&mut spans, &node, &theme, 0, 8, Some(&lit), false, Some(&merged), None);
 
         let dot = spans.iter().find(|s| s.content.contains('●')).unwrap();
         assert!(
@@ -1948,7 +2156,7 @@ mod tests {
 
         let mut spans: Vec<Span> = Vec::new();
         // cap = 3 leaves room for 2 glyphs plus the `…` marker.
-        render_cells_unicode(&mut spans, &node, &theme, 0, 3, Some(&lit), false, None);
+        render_cells_unicode(&mut spans, &node, &theme, 0, 3, Some(&lit), false, None, None);
 
         let commit = spans.iter().find(|s| s.content.contains('●')).unwrap();
         assert!(!commit.style.add_modifier.contains(Modifier::DIM));
@@ -2093,6 +2301,7 @@ mod tests {
             merged_branches: &HashSet::new(),
             merged_dim: true,
             merged_lane_oids: None,
+            merged_exempt: None,
             base_update_merges: &HashSet::new(),
             metadata_columns: cols,
             graph_width: 4,

--- a/src/ui/graph_view/pixel_dim.rs
+++ b/src/ui/graph_view/pixel_dim.rs
@@ -170,8 +170,14 @@ pub fn dim_pixel_specs_window(
     // Merged-lane dim (#108), gated the same way the unicode path is: dim on and
     // hide off. `None` = feature off, so the core skips the merged-lane pass.
     let merged_oids = (app.merged.dim && !app.merged.hide).then_some(&app.merged.lane_oids);
+    // The selected commit is exempt (mirrors the unicode path's
+    // `RowRenderCtx::merged_exempt`): its dot and its own strokes stay live.
+    let merged_exempt = app
+        .selected_commit_node()
+        .and_then(|n| n.commit.as_ref())
+        .map(|c| c.oid);
     dim_specs_window_core(
-        base, &row_oids, &force_dim, lit, lane_rgb, merged_oids, win_start, win_end,
+        base, &row_oids, &force_dim, lit, lane_rgb, merged_oids, merged_exempt, win_start, win_end,
     )
 }
 
@@ -212,6 +218,7 @@ fn dim_specs_window_core(
     lit: &std::collections::HashMap<crate::git::graph::CellEdge, git2::Oid>,
     lane_rgb: &std::collections::HashMap<git2::Oid, [u8; 3]>,
     merged_oids: Option<&HashSet<git2::Oid>>,
+    merged_exempt: Option<git2::Oid>,
     win_start: usize,
     win_end: usize,
 ) -> Vec<crate::ui::graph_pixels::RowSpec> {
@@ -245,8 +252,8 @@ fn dim_specs_window_core(
         // to a merged branch's lane — exactly the strokes hide-merged removes.
         // Only ever SETS dim, so it composes on top of force-dim / trace above.
         if let (Some(m), Some(o)) = (merged_oids, row_oids.get(i)) {
-            apply_merged_lane_dim(&mut spec.cells, o.cells, m);
-            apply_merged_lane_dim(&mut spec.underlay, o.underlay, m);
+            apply_merged_lane_dim(&mut spec.cells, o.cells, m, merged_exempt);
+            apply_merged_lane_dim(&mut spec.underlay, o.underlay, m, merged_exempt);
         }
         spec
     };
@@ -605,7 +612,7 @@ mod tests {
         let (base, oids, lit, lane_rgb) = window_dim_fixture(10);
         let ro = row_oids_of(&oids);
         let ff = no_force(base.len());
-        let out = dim_specs_window_core(&base, &ro, &ff, &lit, &lane_rgb, None, 3, 7);
+        let out = dim_specs_window_core(&base, &ro, &ff, &lit, &lane_rgb, None, None, 3, 7);
 
         assert_eq!(out.len(), base.len(), "result keeps full length");
         for (i, spec) in out.iter().enumerate() {
@@ -630,8 +637,8 @@ mod tests {
         let (base, oids, lit, lane_rgb) = window_dim_fixture(12);
         let ro = row_oids_of(&oids);
         let ff = no_force(base.len());
-        let full = dim_specs_window_core(&base, &ro, &ff, &lit, &lane_rgb, None, 0, base.len());
-        let windowed = dim_specs_window_core(&base, &ro, &ff, &lit, &lane_rgb, None, 4, 9);
+        let full = dim_specs_window_core(&base, &ro, &ff, &lit, &lane_rgb, None, None, 0, base.len());
+        let windowed = dim_specs_window_core(&base, &ro, &ff, &lit, &lane_rgb, None, None, 4, 9);
         for i in 4..9 {
             assert_eq!(windowed[i], full[i], "row {i} matches the full-range dim");
         }
@@ -642,7 +649,7 @@ mod tests {
         let (base, oids, lit, lane_rgb) = window_dim_fixture(5);
         let ro = row_oids_of(&oids);
         let ff = no_force(base.len());
-        let out = dim_specs_window_core(&base, &ro, &ff, &lit, &lane_rgb, None, 2, 2);
+        let out = dim_specs_window_core(&base, &ro, &ff, &lit, &lane_rgb, None, None, 2, 2);
         assert_eq!(out.len(), 5);
         assert!(out.iter().all(|s| s.cells.is_empty()));
     }
@@ -658,7 +665,7 @@ mod tests {
         // Row 2 is a base-update merge; the rest are ordinary rows.
         let mut ff = no_force(base.len());
         ff[2] = true;
-        let out = dim_specs_window_core(&base, &ro, &ff, &lit, &lane_rgb, None, 0, base.len());
+        let out = dim_specs_window_core(&base, &ro, &ff, &lit, &lane_rgb, None, None, 0, base.len());
 
         // Row 2's connector is fully dimmed by force-dim...
         assert!(
@@ -690,6 +697,7 @@ mod tests {
             &empty_lit,
             &empty_rgb,
             Some(&merged),
+            None,
             0,
             base.len(),
         );
@@ -719,7 +727,7 @@ mod tests {
         let empty_rgb = std::collections::HashMap::new();
 
         let out = dim_specs_window_core(
-            &base, &ro, &ff, &empty_lit, &empty_rgb, None, 0, base.len(),
+            &base, &ro, &ff, &empty_lit, &empty_rgb, None, None, 0, base.len(),
         );
 
         assert!(
@@ -783,7 +791,7 @@ mod tests {
 
         // Tracing lights only the trunk: the spoke cell dims → so must the tail.
         let lit_trunk = [(trunk_edge, oid(3))].into_iter().collect();
-        let out = dim_specs_window_core(&base, &ro, &ff, &lit_trunk, &HashMap::new(), None, 0, 2);
+        let out = dim_specs_window_core(&base, &ro, &ff, &lit_trunk, &HashMap::new(), None, None, 0, 2);
         assert!(out[0].cells[2].dim, "spoke cell dims off-lineage");
         assert!(out[1].incoming[0].dim, "tail dims with its source spoke");
 
@@ -791,7 +799,7 @@ mod tests {
         let red = [255u8, 0, 0];
         let lit_branch = [(branch_edge, oid(2))].into_iter().collect();
         let lane_rgb = [(oid(2), red)].into_iter().collect();
-        let out = dim_specs_window_core(&base, &ro, &ff, &lit_branch, &lane_rgb, None, 0, 2);
+        let out = dim_specs_window_core(&base, &ro, &ff, &lit_branch, &lane_rgb, None, None, 0, 2);
         assert!(!out[1].incoming[0].dim, "lit tail stays bright");
         assert_eq!(out[1].incoming[0].color, red, "tail takes the spoke's traced color");
     }

--- a/src/ui/graph_view/row.rs
+++ b/src/ui/graph_view/row.rs
@@ -165,6 +165,11 @@ pub(super) struct RowRenderCtx<'a> {
     /// graph strokes (any cell edge touching one of these commits) dim — the
     /// same strokes hide-merged would remove.
     pub merged_lane_oids: Option<&'a HashSet<git2::Oid>>,
+    /// The selected commit, exempt from merged-lane dimming: any stroke touching
+    /// it renders live (see `edge_touches_merged`), pairing with the selected
+    /// row's text un-mute in [`resolve_row_model`] so the commit under the
+    /// cursor never reads greyed-out.
+    pub merged_exempt: Option<git2::Oid>,
     pub base_update_merges: &'a HashSet<git2::Oid>,
     pub metadata_columns: MetadataColumns,
     /// Graph column width cap (glyph budget), same for every row this frame.
@@ -228,6 +233,14 @@ pub(super) fn resolve_row_model(
     is_base_update: bool,
     is_merged_lane: bool,
 ) -> RowModel {
+    // Selection exemption: the row under the cursor never reads merged-dimmed.
+    // The widget-level `selection_style` only subtracts the DIM bit; the muted
+    // *foreground* would survive it, so the merged-lane mute is dropped here
+    // entirely while selected (strokes are exempted in the cell renderers via
+    // `RowRenderCtx::merged_exempt`). Deliberately only for the merged-lane
+    // mute — muted/collapsed merges and base-update rows keep their treatment
+    // when selected, since those describe the commit's *kind*, not its lane.
+    let is_merged_lane = is_merged_lane && !flags.is_selected;
     // PR-merge commit (#52): a merge that landed a GitHub PR reads as machinery,
     // not authored work, so its message renders greyed (an explicit muted color,
     // distinct from the plain DIM used for ordinary muted merges). Detection is
@@ -340,7 +353,10 @@ pub(super) fn resolve_row_model(
     )
     .into_iter()
     .map(|mut chip| {
+        // Selected rows skip the mute (same exemption as the row text above):
+        // a chip on the row being inspected keeps its full lane hue.
         let is_merged = ctx.merged_dim
+            && !flags.is_selected
             && chip
                 .branch
                 .as_deref()

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -491,7 +491,7 @@ impl Theme {
             .padding(Padding::horizontal(1))
     }
 
-    /// Muted style for commit-detail field labels (Author:/Date:/Sig:) and other
+    /// Muted style for commit-detail field labels (Author:/Date:) and other
     /// metadata captions, so the label recedes and its value reads first.
     pub fn metadata_label_style(&self) -> Style {
         Style::default().fg(self.text_muted)

--- a/tests/viewer_features_test.rs
+++ b/tests/viewer_features_test.rs
@@ -1,7 +1,6 @@
-//! Integration tests for the three viewer features:
+//! Integration tests for the viewer features:
 //!   1. Compare two arbitrary commits (tree-to-tree diff + mark/compare flow)
 //!   2. Per-file history (git log --follow) + opening a history entry's diff
-//!   3. Commit signature status (%G? plumbing)
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -12,10 +11,7 @@ use tempfile::TempDir;
 use keifu::action::Action;
 use keifu::app::{App, AppMode, FileHistoryEntry};
 use keifu::diff_cache::DiffTarget;
-use keifu::git::{
-    commit_signature_status, file_history, signature_status_label, CommitDiffInfo, FileChangeKind,
-    GitRepository,
-};
+use keifu::git::{file_history, CommitDiffInfo, FileChangeKind, GitRepository};
 
 // ── Helpers ─────────────────────────────────────────────────────────
 
@@ -252,21 +248,6 @@ fn file_history_enter_opens_that_commits_file_diff() {
         }
         other => panic!("expected FileDiff, got {other:?}"),
     }
-
-    drop(dir);
-}
-
-// ── Feature 3: signature status ─────────────────────────────────────
-
-#[test]
-fn unsigned_commit_reads_as_unsigned() {
-    let (dir, repo) = init_repo();
-    let c1 = commit_at(&repo, "f.txt", "1\n", "c1", 1000);
-    let path = dir.path().to_string_lossy().to_string();
-
-    // No GPG key material in CI, so the commit is genuinely unsigned.
-    assert_eq!(commit_signature_status(&path, c1).unwrap(), 'N');
-    assert_eq!(signature_status_label('N'), "unsigned");
 
     drop(dir);
 }


### PR DESCRIPTION
Closes #119, closes #120, closes #121.

Three changes in one PR, as requested:

## 1. Commit-detail signature line removed (#119)
The `Sig:` line is gone from the commit-detail pane, along with the entire dead slice behind it: the per-selection preload, `App.sig_status_cache`, `load_signature_status`, the `%G?` git-layer helpers (`commit_signature_status`, `signature_status_label`), and their tests. No other consumer existed.

## 2. Selected commit is exempt from merged-lane dimming (#120)
Selecting a dimmed merged-branch commit previously left it greyed: the widget-level `selection_style` only strips the DIM *bit*, so the muted foreground and dimmed strokes survived. Now the selection exempts the commit under the cursor:
- `resolve_row_model` drops the merged-lane mute on the selected row — text columns un-grey, selection BOLD applies, and merged branch chips keep their full lane hue (the `merged` badge stays as the indicator).
- Both stroke renderers exempt any edge touching the selected commit's oid (`edge_touches_merged` gains an `exempt` parameter, threaded as `RowRenderCtx::merged_exempt` and through the pixel dim core), so the dot and its own strokes render live while the rest of the lane keeps dimming.
- Deliberately scoped to the merged-lane mute: muted/collapsed merges and base-update rows keep their treatment when selected, since those describe the commit's kind, not its lane.

## 3. Transitive merged classification (#121)
`classify_merged_branches_with_targets` now iterates to a fixed point: after each pass, tips of newly-classified branches join the tested tip set and still-unclassified branches are re-tested, until a pass classifies nothing new. This catches chains with no direct trunk signal — a sub-branch merged into a feature that was then squashed, stacked squashes N levels deep, and old pointers into a merged branch's line. The trunk first-parent "behind" guard stays trunk-only on purpose (an old pointer into a *merged* line is landed work, unlike one into a live trunk). Tips are extended only between rounds so same-tip twins classify together before the tip-equality guard could refuse one. `--explain-merged` gains a transitive section naming the merged branch each transitive merge landed through. Both dim and hide widen automatically since they read the same set.

## Tests & verification
- 4 new classification tests (transitive squash, 3-level chain, negative case, merged-line old pointer), 4 new render-decision/stroke tests (row unmute, chip hue, unicode + pixel stroke exemption), plus updated helper signatures.
- `cargo test`: 1273 passed. `cargo clippy --all-targets`: clean.
- Verified in the real TUI via the debug server on a fixture repo (sub → feature via merge commit, feature → main via squash): both `[feature]` and `[sub]` show the `merged` badge, `Shift+H` hides the whole chain, and the commit-detail pane shows no `Sig:` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtLHMXcuxvLYQgnRe9v6jw