### PR TITLE
fix: render approved PR tick green

### DIFF
--- a/src/ui/graph_view/badges.rs
+++ b/src/ui/graph_view/badges.rs
@@ -28,6 +28,17 @@ const PR_COMMENT_ICON: char = '\u{f41f}'; // nf-oct-comment
 pub struct PrBadge {
     pub text: String,
     pub color: Color,
+    pub marker: PrBadgeMarker,
+}
+
+/// The review marker appended to an open-PR badge. Kept separate from the
+/// compact text so rendering can give an approved check its semantic color
+/// without changing the CI/merge color of the rest of the badge.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PrBadgeMarker {
+    None,
+    Approved,
+    ChangesRequested,
 }
 
 /// Badge appended to a branch already merged into the trunk (merge or squash).
@@ -77,6 +88,11 @@ pub(super) fn pr_for_row(
     Some(PrBadge {
         text: pr_badge_text(pr),
         color: pr_badge_color(pr, theme),
+        marker: match pr.review {
+            ReviewState::None => PrBadgeMarker::None,
+            ReviewState::Approved => PrBadgeMarker::Approved,
+            ReviewState::ChangesRequested => PrBadgeMarker::ChangesRequested,
+        },
     })
 }
 

--- a/src/ui/graph_view/badges.rs
+++ b/src/ui/graph_view/badges.rs
@@ -41,6 +41,27 @@ pub enum PrBadgeMarker {
     ChangesRequested,
 }
 
+impl PrBadgeMarker {
+    /// Marker text, including the separator from the PR number.
+    pub(super) fn suffix(self) -> Option<String> {
+        match self {
+            Self::None => None,
+            Self::Approved => Some(format!(" {PR_APPROVED_ICON}")),
+            Self::ChangesRequested => Some(format!(" {PR_CHANGES_ICON}")),
+        }
+    }
+}
+
+impl From<ReviewState> for PrBadgeMarker {
+    fn from(review: ReviewState) -> Self {
+        match review {
+            ReviewState::None => Self::None,
+            ReviewState::Approved => Self::Approved,
+            ReviewState::ChangesRequested => Self::ChangesRequested,
+        }
+    }
+}
+
 /// Badge appended to a branch already merged into the trunk (merge or squash).
 /// Rendered muted/dimmed; the branch chips themselves are dimmed to match.
 /// Derived from [`MERGE_ICON`] so the glyph's codepoint exists in one place.
@@ -88,11 +109,7 @@ pub(super) fn pr_for_row(
     Some(PrBadge {
         text: pr_badge_text(pr),
         color: pr_badge_color(pr, theme),
-        marker: match pr.review {
-            ReviewState::None => PrBadgeMarker::None,
-            ReviewState::Approved => PrBadgeMarker::Approved,
-            ReviewState::ChangesRequested => PrBadgeMarker::ChangesRequested,
-        },
+        marker: pr.review.into(),
     })
 }
 
@@ -119,23 +136,16 @@ fn pr_for_row_info<'p>(
     })
 }
 
-/// Compact badge text for an open PR, e.g. ` #12 ✓ ` (approved with outside
-/// comments). Review marker first (approved / changes-requested), then a
-/// comment marker when a non-author has commented.
+/// Compact badge text for an open PR, e.g. ` #12 ✓ `. Review markers supersede
+/// the outside-activity marker because the stronger state already signals that
+/// someone acted on the PR.
 fn pr_badge_text(pr: &PrInfo) -> String {
     let mut s = format!("{} #{}", PR_BADGE_ICON, pr.number);
-    match pr.review {
-        ReviewState::Approved => {
-            s.push(' ');
-            s.push(PR_APPROVED_ICON);
-        }
-        ReviewState::ChangesRequested => {
-            s.push(' ');
-            s.push(PR_CHANGES_ICON);
-        }
-        ReviewState::None => {}
+    let marker = PrBadgeMarker::from(pr.review);
+    if let Some(suffix) = marker.suffix() {
+        s.push_str(&suffix);
     }
-    if pr.outside_activity {
+    if pr.outside_activity && marker == PrBadgeMarker::None {
         s.push(' ');
         s.push(PR_COMMENT_ICON);
     }

--- a/src/ui/graph_view/badges.rs
+++ b/src/ui/graph_view/badges.rs
@@ -268,7 +268,7 @@ mod tests {
     }
 
     #[test]
-    fn pr_badge_appends_review_then_comment_markers() {
+    fn pr_badge_uses_review_marker_instead_of_comment_marker() {
         // Plain: no markers.
         let plain = pr_badge_text(&pr_with(1, CiStatus::Pass, ReviewState::None, false));
         assert!(!plain.contains(PR_APPROVED_ICON));
@@ -287,17 +287,26 @@ mod tests {
         assert!(changes.contains(PR_CHANGES_ICON));
         assert!(!changes.contains(PR_APPROVED_ICON));
 
-        // Outside comment → comment glyph, appended after the review marker.
+        // Outside activity with a review marker is already represented by that
+        // stronger marker, so no redundant comment glyph is appended.
         let both = pr_badge_text(&pr_with(12, CiStatus::Pass, ReviewState::Approved, true));
-        assert!(both.contains(PR_APPROVED_ICON) && both.contains(PR_COMMENT_ICON));
-        let check_at = both.find(PR_APPROVED_ICON).unwrap();
-        let comment_at = both.find(PR_COMMENT_ICON).unwrap();
-        assert!(
-            check_at < comment_at,
-            "review marker precedes comment: {both:?}"
-        );
-        // Icon(1)+" #12"(4) + " ✓"(2) + " ⌘"(2) = 9 columns.
-        assert_eq!(display_width(&both), 9);
+        assert!(both.contains(PR_APPROVED_ICON));
+        assert!(!both.contains(PR_COMMENT_ICON));
+        // Icon(1)+" #12"(4) + " ✓"(2) = 7 columns.
+        assert_eq!(display_width(&both), 7);
+
+        let changes = pr_badge_text(&pr_with(
+            12,
+            CiStatus::Pass,
+            ReviewState::ChangesRequested,
+            true,
+        ));
+        assert!(changes.contains(PR_CHANGES_ICON));
+        assert!(!changes.contains(PR_COMMENT_ICON));
+
+        // Without a review marker, outside activity remains visible.
+        let comment_only = pr_badge_text(&pr_with(12, CiStatus::Pass, ReviewState::None, true));
+        assert!(comment_only.contains(PR_COMMENT_ICON));
     }
 
     #[test]
@@ -395,10 +404,9 @@ mod tests {
     }
 
     #[test]
-    fn pr_badge_encodes_approved_and_comment_state() {
-        // #43: the badge for a PR resolved by head commit encodes the approved +
-        // outside-comment markers. Asserts the badge *decision* (text) directly
-        // rather than scanning a full render.
+    fn pr_badge_encodes_approved_without_redundant_comment_state() {
+        // #43: the badge for a PR resolved by head commit encodes the approved
+        // marker, which supersedes the outside-comment marker.
         let theme = Theme::dark();
         let mut approved = pr(1);
         approved.head_oid = Some(oid(5).to_string());
@@ -415,11 +423,7 @@ mod tests {
             "approved glyph present: {:?}",
             badge.text
         );
-        assert!(
-            badge.text.contains(PR_COMMENT_ICON),
-            "comment glyph present: {:?}",
-            badge.text
-        );
+        assert!(!badge.text.contains(PR_COMMENT_ICON), "badge: {badge:?}");
     }
 
     #[test]

--- a/src/ui/graph_view/mod.rs
+++ b/src/ui/graph_view/mod.rs
@@ -677,6 +677,35 @@ mod tests {
     }
 
     #[test]
+    fn approved_pr_tick_is_green_and_hides_redundant_activity_marker() {
+        // The rendering seam: even a failed-CI PR keeps its approval tick green,
+        // while its badge retains the CI color. A review marker supersedes the
+        // outside-activity message marker.
+        let mut approved = pr_head(7, 5);
+        approved.ci = CiStatus::Fail;
+        approved.review = ReviewState::Approved;
+        approved.outside_activity = true;
+        let open = open_map(vec![("feat", approved)]);
+        let line = render_row(&commit_node(5, "head", &[]), &open, false);
+        let theme = Theme::dark();
+
+        assert!(
+            line.spans
+                .iter()
+                .any(|span| span.content.as_ref() == " \u{f42e}"
+                    && span.style.fg == Some(theme.pr_ci_pass)),
+            "approved tick must render in success green: {line:?}"
+        );
+        assert!(
+            !line
+                .spans
+                .iter()
+                .any(|span| span.content.contains('\u{f41f}')),
+            "approved PR must not also render a message marker: {line:?}"
+        );
+    }
+
+    #[test]
     fn pr_badge_renders_before_branch_pill() {
         // #98: the PR badge should lead the row, not trail the branch pill.
         let open = open_map(vec![("feat", pr_head(77, 5))]);

--- a/src/ui/graph_view/row.rs
+++ b/src/ui/graph_view/row.rs
@@ -22,7 +22,9 @@ use crate::{
     ui::theme::Theme,
 };
 
-use super::badges::{merged_badge, merged_style, pr_for_row, PrBadge, PR_BADGE_ICON};
+use super::badges::{
+    merged_badge, merged_style, pr_for_row, PrBadge, PrBadgeMarker, PR_BADGE_ICON,
+};
 use super::chips::{optimize_branch_display, BranchChip};
 use super::metrics::{display_width, format_date_field, truncate_to_width};
 use super::MERGE_ICON;
@@ -495,7 +497,23 @@ fn layout_row<'a>(
             x_end: (chip_start + display_width(&badge.text)) as u16,
             target: ChipTarget::PrBadge,
         });
-        spans.push(Span::styled(badge.text.clone(), style));
+        if let Some(marker_suffix) = badge.marker.suffix() {
+            let prefix = badge
+                .text
+                .strip_suffix(&marker_suffix)
+                .expect("badge marker suffix matches compact badge text");
+            spans.push(Span::styled(prefix.to_string(), style));
+            let marker_style = if badge.marker == PrBadgeMarker::Approved {
+                Style::default()
+                    .fg(ctx.theme.pr_ci_pass)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                style
+            };
+            spans.push(Span::styled(marker_suffix, marker_style));
+        } else {
+            spans.push(Span::styled(badge.text.clone(), style));
+        }
         spans.push(Span::raw(" "));
     }
 


### PR DESCRIPTION
Fixes #133

## Acceptance Criteria
- [ ] An approved open PR renders its check glyph with the success-green theme color independently of CI or merge state.
- [ ] An approved open PR with outside activity renders the approval check without a message glyph.
- [ ] A changes-requested open PR with outside activity renders the ± glyph without a message glyph.
- [ ] An open PR with outside activity but no review marker continues to render the message glyph.

## Verification
- `cargo test ui::graph_view::badges`
- `cargo test approved_pr_tick_is_green_and_hides_redundant_activity_marker`
- `cargo clippy --all-targets -- -D warnings`
- Real TUI debug-server dump and clean shutdown.

Note: the full `cargo test` suite has one environment-sensitive baseline failure (`commit_without_configured_user_maps_to_friendly_error`) because this runner has a global Git identity; the focused tests, all other 913 tests, and clippy pass.