### PR TITLE
Fix mute base-update merges for live PR refs

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1742,9 +1742,18 @@ impl App {
         let fallback = crate::git::merged::base_branch(&self.branches).map(|b| b.tip_oid);
         let mut pairs: Vec<(git2::Oid, git2::Oid)> = self
             .open_prs
-            .values()
-            .filter_map(|p| p.head_oid().map(|head| (head, p)))
-            .flat_map(|(head, p)| {
+            .iter()
+            .flat_map(|(head_ref, p)| {
+                // The graph may have advanced past GitHub's `headRefOid`:
+                // immediately after a local base merge, the visible feature
+                // tip is newer until it is pushed and the PR refresh completes.
+                // Retain GitHub's OID for refs not known locally.
+                let mut heads = crate::git::merged::branch_ref_tips(&self.branches, head_ref);
+                if let Some(head) = p.head_oid() {
+                    heads.push(head);
+                }
+                heads.sort();
+                heads.dedup();
                 let tips = match p.base_ref.as_deref() {
                     Some(base) => crate::git::merged::base_ref_tips(&self.branches, base),
                     None => Vec::new(),
@@ -1756,7 +1765,10 @@ impl App {
                 } else {
                     tips
                 };
-                tips.into_iter().map(move |tip| (head, tip))
+                heads
+                    .into_iter()
+                    .flat_map(|head| tips.iter().copied().map(move |tip| (head, tip)))
+                    .collect::<Vec<_>>()
             })
             .collect();
         // Sorted so the signature is order-independent.

--- a/src/git/merged.rs
+++ b/src/git/merged.rs
@@ -770,13 +770,10 @@ pub fn merged_local_branches(
 /// practice; this window is generous.
 const BASE_UPDATE_SCAN_LIMIT: usize = 400;
 
-/// Every locally-known tip of the branch named `base_ref` (a PR's `baseRefName`,
-/// always unqualified): the local branch of that name plus each remote's
-/// `<remote>/<base_ref>`. All tips are returned rather than picking one because
-/// local and remote may disagree (unpushed / unfetched base commits) and a
-/// back-merge's second parent need only be reachable from *some* tip of the
-/// base — testing each costs one bounded walk per tip.
-pub fn base_ref_tips(branches: &[BranchInfo], base_ref: &str) -> Vec<Oid> {
+/// Every locally-known tip of a branch name: the local branch plus each remote
+/// mirror. All tips are returned because local and remote refs may disagree
+/// while keifu renders commits reachable from either.
+pub fn branch_ref_tips(branches: &[BranchInfo], branch_name: &str) -> Vec<Oid> {
     let mut tips: Vec<Oid> = branches
         .iter()
         .filter(|b| {
@@ -786,9 +783,9 @@ pub fn base_ref_tips(branches: &[BranchInfo], base_ref: &str) -> Vec<Oid> {
                 // `origin/feature/dev` for base `dev`.
                 b.name
                     .split_once('/')
-                    .is_some_and(|(_, rest)| rest == base_ref)
+                    .is_some_and(|(_, rest)| rest == branch_name)
             } else {
-                b.name == base_ref
+                b.name == branch_name
             }
         })
         .map(|b| b.tip_oid)
@@ -796,6 +793,13 @@ pub fn base_ref_tips(branches: &[BranchInfo], base_ref: &str) -> Vec<Oid> {
     tips.sort();
     tips.dedup();
     tips
+}
+
+/// Every locally-known tip of the branch named `base_ref` (a PR's
+/// `baseRefName`). Kept as a named wrapper so callers document which side of a
+/// PR pair they are resolving.
+pub fn base_ref_tips(branches: &[BranchInfo], base_ref: &str) -> Vec<Oid> {
+    branch_ref_tips(branches, base_ref)
 }
 
 /// Classify **base-update ("back-merge") commits**: merge commits that sit on an

--- a/src/ui/graph_view/mod.rs
+++ b/src/ui/graph_view/mod.rs
@@ -1812,8 +1812,8 @@ mod tests {
 
     #[test]
     fn is_base_update_row_predicate_is_the_shared_contract() {
-        // The single predicate both renderers key off. Only ON + merge + in-set +
-        // not-HEAD qualifies; anything else must not mute.
+        // The single predicate both renderers key off. Only ON + merge + in-set
+        // qualifies; anything else must not mute.
         let mut set = HashSet::new();
         set.insert(oid(30));
         let merge = merge_node_full(30, "Merge main into feature", [1, 2]);
@@ -1829,12 +1829,13 @@ mod tests {
             !is_base_update_row(&merge, true, &HashSet::new()),
             "not in set never mutes"
         );
-        // HEAD is never muted even when it qualifies otherwise.
+        // A just-created base update is commonly the feature branch's HEAD, and
+        // must still mute when the setting is enabled.
         let mut head = merge_node_full(30, "Merge main into feature", [1, 2]);
         head.is_head = true;
         assert!(
-            !is_base_update_row(&head, true, &set),
-            "HEAD is never muted"
+            is_base_update_row(&head, true, &set),
+            "HEAD base-update merges are muted"
         );
         // A non-merge commit in the set is not a back-merge.
         let mut single = merge_node_full(30, "regular", [1, 2]);
@@ -2473,9 +2474,9 @@ mod tests {
     }
 
     #[test]
-    fn head_is_immune_to_every_mute_category() {
-        // Four categories exclude HEAD in their own definitions, so a HEAD row
-        // that otherwise qualifies is never muted.
+    fn head_base_update_merge_is_muted_while_other_merge_mutes_stay_exempt() {
+        // A base-update merge is frequently the current feature HEAD, so it is
+        // intentionally unlike the ordinary PR/merge/collapse mute categories.
         let base_update = {
             let mut node = merge_node_full(70, "Merge main into feature", [1, 2]);
             node.is_head = true;
@@ -2502,8 +2503,8 @@ mod tests {
                 &HashSet::new(),
             )
         };
+        assert!(base_update.row_is_muted, "base-update: HEAD is muted");
         for (name, model) in [
-            ("base-update", base_update),
             ("pr-merge", pr_merge),
             ("muted-merge", muted_merge),
             ("collapse-merge", collapse_merge),

--- a/src/ui/graph_view/mod.rs
+++ b/src/ui/graph_view/mod.rs
@@ -285,7 +285,8 @@ fn render_graph_line<'a>(
     // message renders strongly muted and its own graph glyphs (the noisy
     // back-merge connector) are force-dimmed. Decided once here (via the shared
     // `is_base_update_row` predicate) so both the unicode cell renderer and the
-    // pixel dim pass agree with the message tail. HEAD is never muted.
+    // pixel dim pass agree with the message tail. HEAD is included because a
+    // fresh base update is normally the feature branch's tip.
     let is_base_update = is_base_update_row(
         node,
         ctx.metadata_columns.mute_base_merges,

--- a/src/ui/graph_view/row.rs
+++ b/src/ui/graph_view/row.rs
@@ -126,15 +126,15 @@ pub(super) fn build_tag_labels(tag_names: &[String], theme: &Theme) -> Vec<(Stri
 /// strongly muted (#55): its message greys+dims and its own graph connector is
 /// force-dimmed so the noisy back-merge line recedes. This is the single source
 /// of truth shared by BOTH renderers — the unicode path (`render_cells_unicode`
-/// force_dim) and the pixel path (`dim_pixel_specs_window` per-row force-dim) —
-/// so they agree on which rows mute. HEAD is never muted.
+/// force_dim) and the pixel path (`dim_pixel_specs_window` per-row force-dim)
+/// agree on which rows mute. A base-update HEAD is deliberately included: it is
+/// the usual outcome directly after refreshing a feature branch from its base.
 pub(super) fn is_base_update_row(
     node: &GraphNode,
     mute_base_merges: bool,
     base_update_merges: &HashSet<git2::Oid>,
 ) -> bool {
     mute_base_merges
-        && !node.is_head
         && node.is_merge()
         && node
             .commit

--- a/tests/app_behavior_test.rs
+++ b/tests/app_behavior_test.rs
@@ -61,6 +61,35 @@ fn commit_to_ref(
         .unwrap()
 }
 
+/// Create a two-parent merge commit on `refname` with an explicit tree. Keeps
+/// the ref-only history setup used by graph tests independent of the checkout.
+fn merge_to_ref(
+    repo: &Repository,
+    refname: &str,
+    first_parent: Oid,
+    second_parent: Oid,
+    path: &str,
+    contents: &str,
+    message: &str,
+) -> Oid {
+    let first = repo.find_commit(first_parent).unwrap();
+    let second = repo.find_commit(second_parent).unwrap();
+    let mut builder = repo.treebuilder(Some(&first.tree().unwrap())).unwrap();
+    let blob = repo.blob(contents.as_bytes()).unwrap();
+    builder.insert(path, blob, 0o100644).unwrap();
+    let tree = repo.find_tree(builder.write().unwrap()).unwrap();
+    let sig = Signature::now("Test User", "test@example.com").unwrap();
+    repo.commit(
+        Some(refname),
+        &sig,
+        &sig,
+        message,
+        &tree,
+        &[&first, &second],
+    )
+    .unwrap()
+}
+
 /// The OID that HEAD currently points at, read from a fresh handle on disk.
 fn head_oid(repo_dir: &Path) -> Oid {
     Repository::open(repo_dir)
@@ -146,6 +175,54 @@ fn commit_file(repo: &Repository, path: &str, contents: &str, message: &str) -> 
 
 fn make_app(repo: GitRepository) -> keifu::app::App {
     keifu::app::App::from_repo(repo).unwrap()
+}
+
+#[test]
+fn base_update_merge_uses_the_live_feature_tip_before_github_refreshes() {
+    let (_td, repo) = init_repo();
+    let root = commit_file(repo.repo(), "base.txt", "base", "root");
+    repo.repo()
+        .branch("dev", &repo.repo().find_commit(root).unwrap(), false)
+        .unwrap();
+    repo.repo()
+        .branch("feature", &repo.repo().find_commit(root).unwrap(), false)
+        .unwrap();
+
+    let feature_before_update = commit_to_ref(
+        repo.repo(),
+        "refs/heads/feature",
+        "feature.txt",
+        "feature",
+        "feature work",
+    );
+    let dev_tip = commit_to_ref(
+        repo.repo(),
+        "refs/heads/dev",
+        "base.txt",
+        "advanced base",
+        "advance dev",
+    );
+    let base_update = merge_to_ref(
+        repo.repo(),
+        "refs/heads/feature",
+        feature_before_update,
+        dev_tip,
+        "base.txt",
+        "advanced base",
+        "Merge dev into feature",
+    );
+
+    let mut app = make_app(repo);
+    app.open_prs = keifu::pr::parse_pr_list(&format!(
+        r#"[{{"number":128,"url":"https://example.test/pr/128","headRefName":"feature","headRefOid":"{feature_before_update}","baseRefName":"dev","title":"feature","state":"OPEN"}}]"#
+    ));
+
+    app.refresh(true).unwrap();
+
+    assert!(
+        app.merged.base_update.value().contains(&base_update),
+        "the visible local base-update merge is muted before GitHub reports its new PR head"
+    );
 }
 
 // ── Graph Navigation ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Classify base-update merges from live local and remote PR branch refs as well as GitHub’s last-known SHA, so newly created base merges are muted immediately. Base-update merge heads now participate in the shared unicode and pixel muting predicate.

## Acceptance Criteria

- [ ] With an open PR whose base is `dev`, a merge that brings `dev` into its feature branch renders muted when “Mute base-update merges” is enabled.
- [ ] The same base-update merge remains normally rendered when the setting is disabled.
- [ ] A merge on an open feature branch that does not bring in its PR base is not misclassified as a base-update merge.

## Test Plan

- `cargo test --test app_behavior_test`
- `env -u GIT_AUTHOR_NAME -u GIT_COMMITTER_NAME cargo test`
- `cargo clippy --all-targets -- -D warnings`
- Real TUI debug-server check against a live feature-branch base-update merge with a deliberately stale GitHub PR head.

Fixes #128