### PR TITLE
Ctrl+P: jump to branch by typing its name

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ keifu (系譜, /keːɸɯ/) is a terminal UI tool that visualizes Git commit grap
 - Branch tracing (`t`) — selecting a commit highlights its full branch line (first-parent ancestry and descendants) and dims every other lane, the way VSCode does on hover; on by default for branchy graphs
 - Real branch filtering — hiding a branch removes its exclusive commits from the graph, not just its label; filter the picker by branch name or by author (`@name`) and bulk-hide a whole author's branches; `Shift+O` hides all remote-only branches at once (remote refs with no matching local branch), composing with the per-branch filter
 - Compare any two commits
-- Command palette (`Ctrl+P` / `:`) — one fuzzy list over commands, branch checkouts, and commit jumps
+- Command palette (`:`) — one fuzzy list over commands, branch checkouts, and commit jumps
 - Session undo (`Ctrl+Z` in the graph) for branch/tag delete, merge, pull, and rename — verified against current state and confirmed before it runs
 - Branch search with fuzzy dropdown UI; commit filter by message/author/hash
 - Full mouse support: click to select and focus, double-click to open, right-click for a context menu, clickable PR/branch chips, scroll-wheel routing, and a drag-resizable graph/detail divider
@@ -178,7 +178,7 @@ The **commit actions menu** (`Enter`, fuzzy-filterable by typing) offers, depend
 
 | Key | Action |
 | --- | --- |
-| `/` | Search branches (incremental fuzzy search) |
+| `Ctrl+P` / `/` | Search branches (incremental fuzzy search) |
 | `↑` / `Ctrl+k` | Select previous result |
 | `↓` / `Ctrl+j` | Select next result |
 | `Enter` | Jump to selected branch |
@@ -188,7 +188,7 @@ The **commit actions menu** (`Enter`, fuzzy-filterable by typing) offers, depend
 
 | Key | Action |
 | --- | --- |
-| `Ctrl+P` / `:` | Command palette — fuzzy-find over commands, branches (checkout), and commits (jump); ↑↓ to move, Enter to run, Esc to close |
+| `:` | Command palette — fuzzy-find over commands, branches (checkout), and commits (jump); ↑↓ to move, Enter to run, Esc to close |
 | `R` | Refresh repository data |
 | `F5` | Full update — fetch all remotes, refetch open PRs, and refresh |
 | `?` | Toggle help |

--- a/src/action.rs
+++ b/src/action.rs
@@ -58,7 +58,7 @@ pub enum Action {
     // Commit comparison (graph)
     MarkForCompare,
 
-    // Open the command palette (Ctrl+P / ':') from Normal mode
+    // Open the command palette (`:`) from Normal mode
     OpenCommandPalette,
 
     // Create / merge a pull request directly (palette shortcuts to the commit

--- a/src/app/graph_actions.rs
+++ b/src/app/graph_actions.rs
@@ -211,14 +211,6 @@ impl App {
                     action: InputAction::CreateBranch,
                 };
             }
-            Action::Search => {
-                self.save_search_position();
-                self.mode = AppMode::Input {
-                    title: "Search branches".to_string(),
-                    input: String::new(),
-                    action: InputAction::Search,
-                };
-            }
             Action::DeleteBranch => {
                 self.open_delete_branch_picker();
             }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1415,12 +1415,7 @@ impl App {
         }
         // Branch quick search opens from any panel in Normal mode.
         if matches!(action, Action::Search) {
-            self.save_search_position();
-            self.mode = AppMode::Input {
-                title: "Search branches".to_string(),
-                input: String::new(),
-                action: InputAction::Search,
-            };
+            self.open_branch_search();
             return Ok(());
         }
         // The settings menu opens from any panel in Normal mode.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -421,7 +421,7 @@ pub enum AppMode {
         entries: Vec<FileHistoryEntry>,
         selected: usize,
     },
-    /// Fuzzy command palette (Ctrl+P): commands, branches, and commits in one
+    /// Fuzzy command palette (`:`): commands, branches, and commits in one
     /// ranked list. Holds the query string and the selected row.
     CommandPalette {
         query: String,
@@ -1411,6 +1411,16 @@ impl App {
         // The command palette opens from any panel in Normal mode.
         if matches!(action, Action::OpenCommandPalette) {
             self.open_command_palette();
+            return Ok(());
+        }
+        // Branch quick search opens from any panel in Normal mode.
+        if matches!(action, Action::Search) {
+            self.save_search_position();
+            self.mode = AppMode::Input {
+                title: "Search branches".to_string(),
+                input: String::new(),
+                action: InputAction::Search,
+            };
             return Ok(());
         }
         // The settings menu opens from any panel in Normal mode.

--- a/src/app/search_ops.rs
+++ b/src/app/search_ops.rs
@@ -3,6 +3,16 @@
 use super::*;
 
 impl App {
+    /// Open branch quick search, preserving the selection for cancellation.
+    pub(crate) fn open_branch_search(&mut self) {
+        self.save_search_position();
+        self.mode = AppMode::Input {
+            title: "Search branches".to_string(),
+            input: String::new(),
+            action: InputAction::Search,
+        };
+    }
+
     /// Update fuzzy search results for the given query
     pub(crate) fn update_fuzzy_search(&mut self, query: &str) {
         self.search_state.fuzzy_matches =

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -194,15 +194,18 @@ fn map_normal_mode(
         return map_editor_mode(key);
     }
 
-    // Command palette: Ctrl+P (or ':' for vim muscle memory) from any panel,
-    // unless a text filter is currently capturing input.
+    // Ctrl+P opens branch quick search from any panel. ':' keeps the command
+    // palette available for vim muscle memory. Neither interrupts a text filter.
     if !files_filter_active && !commit_filter_active {
         let ctrl_p =
             key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('p');
         let colon = !key.modifiers.contains(KeyModifiers::CONTROL)
             && !key.modifiers.contains(KeyModifiers::ALT)
             && key.code == KeyCode::Char(':');
-        if ctrl_p || colon {
+        if ctrl_p {
+            return Some(Action::Search);
+        }
+        if colon {
             return Some(Action::OpenCommandPalette);
         }
 

--- a/src/palette.rs
+++ b/src/palette.rs
@@ -198,7 +198,7 @@ pub fn command_registry() -> Vec<PaletteEntry> {
             Action::OpenBranchFilter,
             always,
         ),
-        entry("Search branches", Some("/"), Action::Search, always),
+        entry("Search branches", Some("Ctrl+P /"), Action::Search, always),
         entry(
             "Load 500 more commits",
             None,

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -156,7 +156,7 @@ fn entries(is_uncommitted: bool) -> Vec<HelpEntry> {
         Row("r", "Refresh   o  Open in browser"),
         Blank,
         Header("Search"),
-        Row("/", "Search branches"),
+        Row("Ctrl+P / /", "Search branches"),
         Blank,
         Header("Mouse"),
         Row("Click", "Select commit/file, focus panel"),
@@ -167,10 +167,7 @@ fn entries(is_uncommitted: bool) -> Vec<HelpEntry> {
         Row("Drag divider", "Resize the graph/detail split"),
         Blank,
         Header("Other"),
-        Row(
-            "Ctrl+P / :",
-            "Command palette (commands, branches, commits)",
-        ),
+        Row(":", "Command palette (commands, branches, commits)"),
         Row(
             "Ctrl+, / ,",
             "Settings menu (toggle/edit persisted settings)",

--- a/tests/app_behavior_test.rs
+++ b/tests/app_behavior_test.rs
@@ -558,6 +558,24 @@ fn search_opens_input_mode() {
 }
 
 #[test]
+fn search_opens_input_mode_from_files_panel() {
+    let (_td, repo) = init_repo();
+    commit_file(repo.repo(), "a.txt", "a", "first");
+    let mut app = make_app(repo);
+    app.focused_panel = FocusedPanel::Files;
+
+    app.handle_action(Action::Search).unwrap();
+
+    assert!(matches!(
+        app.mode,
+        AppMode::Input {
+            action: keifu::app::InputAction::Search,
+            ..
+        }
+    ));
+}
+
+#[test]
 fn create_branch_opens_input_mode() {
     let (_td, repo) = init_repo();
     commit_file(repo.repo(), "a.txt", "a", "first");

--- a/tests/app_behavior_test.rs
+++ b/tests/app_behavior_test.rs
@@ -9,6 +9,7 @@
 use std::fs;
 use std::path::Path;
 
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use git2::{Oid, Repository, Signature, Status};
 use tempfile::TempDir;
 
@@ -17,6 +18,7 @@ use keifu::app::{
     App, AppMode, CommitMenuItem, ConfirmAction, FilesPaneItem, FocusedPanel, InputAction,
 };
 use keifu::git::GitRepository;
+use keifu::keybindings::map_key_to_action;
 
 // ── Helpers ─────────────────────────────────────────────────────────
 
@@ -1015,6 +1017,99 @@ fn search_workflow() {
     // Cancel search
     app.handle_action(Action::Cancel).unwrap();
     assert!(matches!(app.mode, AppMode::Normal));
+}
+
+#[test]
+fn ctrl_p_search_navigates_confirms_and_cancels_branch_selection() {
+    let (_td, repo) = init_repo();
+    commit_file(repo.repo(), "a.txt", "a", "initial");
+    {
+        let head = repo.repo().head().unwrap().peel_to_commit().unwrap();
+        repo.repo().branch("feature-search", &head, false).unwrap();
+    }
+    commit_to_ref(
+        repo.repo(),
+        "refs/heads/feature-search",
+        "feature.txt",
+        "feature",
+        "feature commit",
+    );
+    let mut app = make_app(repo);
+    let (feature_position, feature_node) = app
+        .graph_nav
+        .branch_positions
+        .iter()
+        .enumerate()
+        .find(|(_, (_, name))| name == "feature-search")
+        .map(|(position, (node, _))| (position, *node))
+        .expect("feature branch must be searchable");
+    let (original_position, original_node) = app
+        .graph_nav
+        .branch_positions
+        .iter()
+        .enumerate()
+        .find(|(_, (_, name))| name != "feature-search")
+        .map(|(position, (node, _))| (position, *node))
+        .expect("the starting branch must remain available");
+    app.graph_nav.selected_branch_position = Some(original_position);
+    app.graph_nav.graph_list_state.select(Some(original_node));
+
+    let ctrl_p = map_key_to_action(
+        KeyEvent::new(KeyCode::Char('p'), KeyModifiers::CONTROL),
+        &app.mode,
+        app.focused_panel,
+        false,
+        false,
+        false,
+    );
+    app.handle_action(ctrl_p.expect("Ctrl+P must open branch search"))
+        .unwrap();
+    for character in "feature".chars() {
+        app.handle_action(Action::InputChar(character)).unwrap();
+    }
+
+    assert_eq!(
+        app.graph_nav.graph_list_state.selected(),
+        Some(feature_node)
+    );
+    assert_eq!(
+        app.graph_nav.selected_branch_position,
+        Some(feature_position)
+    );
+
+    app.handle_action(Action::Confirm).unwrap();
+    assert!(matches!(app.mode, AppMode::Normal));
+    assert_eq!(
+        app.graph_nav.graph_list_state.selected(),
+        Some(feature_node)
+    );
+
+    app.graph_nav.selected_branch_position = Some(original_position);
+    app.graph_nav.graph_list_state.select(Some(original_node));
+    let ctrl_p = map_key_to_action(
+        KeyEvent::new(KeyCode::Char('p'), KeyModifiers::CONTROL),
+        &app.mode,
+        app.focused_panel,
+        false,
+        false,
+        false,
+    );
+    app.handle_action(ctrl_p.expect("Ctrl+P must open branch search"))
+        .unwrap();
+    for character in "feature".chars() {
+        app.handle_action(Action::InputChar(character)).unwrap();
+    }
+    app.handle_action(Action::Cancel).unwrap();
+
+    assert!(matches!(app.mode, AppMode::Normal));
+    assert_eq!(
+        app.graph_nav.graph_list_state.selected(),
+        Some(original_node)
+    );
+    assert_eq!(
+        app.graph_nav.selected_branch_position,
+        Some(original_position)
+    );
 }
 
 // ── Workflow: Uncommitted Changes Node Lifecycle ────────────────────

--- a/tests/keybindings_test.rs
+++ b/tests/keybindings_test.rs
@@ -87,6 +87,15 @@ fn alt_slash_toggles_layout() {
     assert_eq!(map_normal_graph(k), Some(Action::ToggleLayout));
 }
 
+#[test]
+fn ctrl_p_opens_branch_search_from_every_panel() {
+    let ctrl_p = key_mod(KeyCode::Char('p'), KeyModifiers::CONTROL);
+
+    assert_eq!(map_normal_graph(ctrl_p), Some(Action::Search));
+    assert_eq!(map_normal_files(ctrl_p), Some(Action::Search));
+    assert_eq!(map_normal_detail(ctrl_p), Some(Action::Search));
+}
+
 // ── Panel navigation ────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
Fixes #134

## Acceptance Criteria

- [ ] Pressing Ctrl+P opens a branch quick picker that accepts typed branch-name search text.
- [ ] The picker narrows its displayed branch choices using the typed text and lets the user select a matching branch.
- [ ] Confirming a selection navigates the graph to that branch’s commit; cancelling leaves the current graph location unchanged.

## Verification

- `cargo test --test keybindings_test --test app_behavior_test`
- `cargo clippy -- -D warnings`
- Real TUI debug-server session: Ctrl+P opened Search branches; typing `fix` displayed matching branches and live-previewed the selected branch.

## Review

- Adversarial review: PASS — Ctrl+P workflow test covers filtering/navigation, confirmation retention, and cancellation restoration.