### PR TITLE
fix: toggle word wrap in commit detail

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -178,6 +178,8 @@ pub enum Action {
     StopEditing,
     CommitChanges,
     AmendCommit,
+    /// Toggle word-wrapping in the commit-detail panel (Ctrl+Alt+W).
+    ToggleCommitDetailWrap,
     StashStaged,
     EditorChar(char),
     EditorNewline,

--- a/src/app/commit_editor_actions.rs
+++ b/src/app/commit_editor_actions.rs
@@ -33,16 +33,7 @@ pub(crate) fn apply_editor_edit(editor: &mut TextEditor, action: &Action) -> boo
 impl App {
     pub(crate) fn handle_commit_detail_action(&mut self, action: Action) -> Result<()> {
         if matches!(action, Action::ToggleCommitDetailWrap) {
-            self.commit_detail_word_wrap = !self.commit_detail_word_wrap;
-            let state = if self.commit_detail_word_wrap {
-                "on"
-            } else {
-                "off"
-            };
-            self.toast(
-                crate::toast::ToastKind::Info,
-                format!("Commit detail line wrap {state}"),
-            );
+            self.toggle_commit_detail_word_wrap();
             return Ok(());
         }
 

--- a/src/app/commit_editor_actions.rs
+++ b/src/app/commit_editor_actions.rs
@@ -32,6 +32,20 @@ pub(crate) fn apply_editor_edit(editor: &mut TextEditor, action: &Action) -> boo
 
 impl App {
     pub(crate) fn handle_commit_detail_action(&mut self, action: Action) -> Result<()> {
+        if matches!(action, Action::ToggleCommitDetailWrap) {
+            self.commit_detail_word_wrap = !self.commit_detail_word_wrap;
+            let state = if self.commit_detail_word_wrap {
+                "on"
+            } else {
+                "off"
+            };
+            self.toast(
+                crate::toast::ToastKind::Info,
+                format!("Commit detail line wrap {state}"),
+            );
+            return Ok(());
+        }
+
         // Ctrl+S opens the stash options menu whether or not the commit-message
         // editor is active; any typed message is carried through as the default.
         if matches!(action, Action::StashStaged) {

--- a/src/app/init.rs
+++ b/src/app/init.rs
@@ -222,7 +222,7 @@ impl App {
             commit_detail_max_scroll: 0,
             commit_editor_line_offset: 0,
             commit_detail_visible_rows: 20,
-            commit_detail_word_wrap: true,
+            commit_detail_word_wrap: ui_state.commit_detail_word_wrap,
             commit_filter: String::new(),
             commit_filter_active: false,
             visible_commit_indices: Vec::new(),

--- a/src/app/init.rs
+++ b/src/app/init.rs
@@ -222,6 +222,7 @@ impl App {
             commit_detail_max_scroll: 0,
             commit_editor_line_offset: 0,
             commit_detail_visible_rows: 20,
+            commit_detail_word_wrap: true,
             commit_filter: String::new(),
             commit_filter_active: false,
             visible_commit_indices: Vec::new(),

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -971,6 +971,9 @@ pub struct App {
     pub commit_editor_line_offset: u16,
     /// Visible rows in the commit detail pane (updated during render)
     pub commit_detail_visible_rows: u16,
+    /// Whether the commit detail panel wraps long lines. Enabled by default to
+    /// preserve the historical display; this is a session-local view choice.
+    pub commit_detail_word_wrap: bool,
 
     // Commit filter (graph panel Ctrl+F)
     pub commit_filter: String,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1804,6 +1804,22 @@ impl App {
         self.toast(crate::toast::ToastKind::Info, format!("Line wrap {state}"));
     }
 
+    /// Toggle soft line-wrapping in the commit-detail panel and persist the
+    /// preference so it matches the sibling file-diff setting.
+    pub(crate) fn toggle_commit_detail_word_wrap(&mut self) {
+        self.commit_detail_word_wrap = !self.commit_detail_word_wrap;
+        self.save_ui_state();
+        let state = if self.commit_detail_word_wrap {
+            "on"
+        } else {
+            "off"
+        };
+        self.toast(
+            crate::toast::ToastKind::Info,
+            format!("Commit detail line wrap {state}"),
+        );
+    }
+
     /// Re-lay-out the file-diff viewer's rendered lines when the wrap toggle or
     /// the pane width has changed since the last layout. Cheap no-op otherwise.
     /// Called from the renderer before it borrows the diff state, so scrolling,

--- a/src/config.rs
+++ b/src/config.rs
@@ -312,6 +312,9 @@ pub struct UiState {
     /// Soft line-wrapping in the file-diff viewer. Off by default (long lines
     /// truncate and scroll horizontally, the historical behavior).
     pub diff_word_wrap: bool,
+    /// Soft line-wrapping in the commit-detail panel. On by default to
+    /// preserve the panel's historical display behavior.
+    pub commit_detail_word_wrap: bool,
     /// Hide branches already merged into the trunk (by merge commit, fast-forward,
     /// or squash) from the graph. Off by default: merged branches are shown but
     /// dimmed, and this toggle removes them entirely.
@@ -346,6 +349,7 @@ impl Default for UiState {
             trace_enabled: true,
             hide_remote_branches: false,
             diff_word_wrap: false,
+            commit_detail_word_wrap: true,
             hide_merged_branches: false,
             dim_merged_branches: true,
             files_group_by_folder: false,
@@ -570,6 +574,7 @@ mod tests {
             trace_enabled: false,
             hide_remote_branches: true,
             diff_word_wrap: false,
+            commit_detail_word_wrap: true,
             hide_merged_branches: false,
             dim_merged_branches: false,
             files_group_by_folder: true,
@@ -693,7 +698,7 @@ mod tests {
     }
 
     #[test]
-    fn diff_word_wrap_defaults_off_and_round_trips() {
+    fn line_wrap_preferences_default_and_round_trip() {
         // Wrap is off by default, including for an older state.toml without the key.
         assert!(!UiState::default().diff_word_wrap);
         let older: UiState = toml::from_str("side_panel_layout = true").unwrap();
@@ -705,6 +710,19 @@ mod tests {
         };
         let restored: UiState = toml::from_str(&toml::to_string(&wrapped).unwrap()).unwrap();
         assert!(restored.diff_word_wrap);
+
+        // Commit detail wrapping is historically on, including for an older
+        // state.toml that predates this preference.
+        assert!(UiState::default().commit_detail_word_wrap);
+        let older: UiState = toml::from_str("side_panel_layout = true").unwrap();
+        assert!(older.commit_detail_word_wrap, "missing key defaults to on");
+
+        let unwrapped = UiState {
+            commit_detail_word_wrap: false,
+            ..UiState::default()
+        };
+        let restored: UiState = toml::from_str(&toml::to_string(&unwrapped).unwrap()).unwrap();
+        assert!(!restored.commit_detail_word_wrap);
     }
 
     #[test]

--- a/src/debug_server.rs
+++ b/src/debug_server.rs
@@ -273,6 +273,7 @@ fn state_json(app: &App) -> Value {
         "hide_stashes": app.hide_stashes,
         "trace_enabled": app.trace_enabled,
         "diff_word_wrap": app.diff_word_wrap,
+        "commit_detail_word_wrap": app.commit_detail_word_wrap,
         "graph_renderer": app.config.ui.graph_renderer.as_str(),
     })
 }

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -500,6 +500,13 @@ fn map_files_filter_mode(key: KeyEvent) -> Option<Action> {
 }
 
 fn map_commit_detail_mode(key: KeyEvent) -> Option<Action> {
+    // Keep the commit-detail preference independent from the file-diff toggle.
+    if key.modifiers.contains(KeyModifiers::CONTROL)
+        && key.modifiers.contains(KeyModifiers::ALT)
+        && matches!(key.code, KeyCode::Char('w') | KeyCode::Char('W'))
+    {
+        return Some(Action::ToggleCommitDetailWrap);
+    }
     match (key.modifiers, key.code) {
         // Scroll
         (KeyModifiers::NONE, KeyCode::Down) => Some(Action::MoveDown),

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -477,6 +477,13 @@ pub fn descriptors() -> Vec<SettingDescriptor> {
             diff_word_wrap
         ),
         state_bool!(
+            "Commit detail line wrap",
+            Files,
+            None,
+            commit_detail_word_wrap,
+            commit_detail_word_wrap
+        ),
+        state_bool!(
             "Group files by folder",
             Files,
             None,
@@ -610,6 +617,7 @@ mod tests {
             trace_enabled: false,
             hide_remote_branches: true,
             diff_word_wrap: true,
+            commit_detail_word_wrap: false,
             hide_merged_branches: true,
             dim_merged_branches: false,
             files_group_by_folder: true,

--- a/src/ui/commit_detail.rs
+++ b/src/ui/commit_detail.rs
@@ -349,3 +349,36 @@ impl<'a> Widget for CommitDetailWidget<'a> {
         Widget::render(commit_paragraph, area, buf);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rendered_text(word_wrap: bool) -> String {
+        let area = Rect::new(0, 0, 14, 8);
+        let mut buffer = Buffer::empty(area);
+        let theme = Theme::dark();
+        CommitDetailWidget {
+            commit_lines: vec![Line::from("abcdefghij klmnop")],
+            is_focused: false,
+            commit_scroll: 0,
+            word_wrap,
+            theme: &theme,
+        }
+        .render(area, &mut buffer);
+
+        let mut rendered = String::new();
+        for y in 0..area.height {
+            for x in 0..area.width {
+                rendered.push_str(buffer[(x, y)].symbol());
+            }
+        }
+        rendered
+    }
+
+    #[test]
+    fn long_commit_detail_lines_render_only_when_word_wrap_is_enabled() {
+        assert!(rendered_text(true).contains("klmnop"));
+        assert!(!rendered_text(false).contains("klmnop"));
+    }
+}

--- a/src/ui/commit_detail.rs
+++ b/src/ui/commit_detail.rs
@@ -16,6 +16,7 @@ pub struct CommitDetailWidget<'a> {
     commit_lines: Vec<Line<'a>>,
     is_focused: bool,
     commit_scroll: u16,
+    word_wrap: bool,
     theme: &'a Theme,
 }
 
@@ -46,7 +47,8 @@ pub fn compute_commit_detail_layout<'a>(
     // Word-wrap never splits a line whose total width already fits within
     // the available width, so when every line fits, the wrapped count is
     // just the line count — skip building (and cloning into) a Paragraph.
-    let commit_wrapped_total = if commit_inner_width == 0
+    let commit_wrapped_total = if !app.commit_detail_word_wrap
+        || commit_inner_width == 0
         || commit_lines.iter().all(|l| l.width() <= commit_inner_width)
     {
         commit_lines.len()
@@ -57,7 +59,7 @@ pub fn compute_commit_detail_layout<'a>(
 
     // Recompute editor line offset using wrapped line counts so the cursor
     // accounts for long hint text that wraps across multiple visual lines.
-    if app.editing_commit_message && commit_inner_width > 0 {
+    if app.editing_commit_message && app.commit_detail_word_wrap && commit_inner_width > 0 {
         let raw_offset = app.commit_editor_line_offset as usize;
         let header_lines = &commit_lines[..raw_offset.min(commit_lines.len())];
         if !header_lines.is_empty() {
@@ -83,6 +85,7 @@ impl<'a> CommitDetailWidget<'a> {
             commit_lines,
             is_focused: app.focused_panel == FocusedPanel::CommitDetail,
             commit_scroll: app.commit_detail_scroll,
+            word_wrap: app.commit_detail_word_wrap,
             theme,
         }
     }
@@ -336,8 +339,12 @@ impl<'a> Widget for CommitDetailWidget<'a> {
 
         let commit_paragraph = Paragraph::new(self.commit_lines)
             .block(commit_block)
-            .scroll((self.commit_scroll, 0))
-            .wrap(Wrap { trim: false });
+            .scroll((self.commit_scroll, 0));
+        let commit_paragraph = if self.word_wrap {
+            commit_paragraph.wrap(Wrap { trim: false })
+        } else {
+            commit_paragraph
+        };
 
         Widget::render(commit_paragraph, area, buf);
     }

--- a/src/ui/help_popup.rs
+++ b/src/ui/help_popup.rs
@@ -134,6 +134,7 @@ fn entries(is_uncommitted: bool) -> Vec<HelpEntry> {
         Blank,
         Header("Commit Panel"),
         Row("↑ / ↓", "Scroll"),
+        Row("Ctrl+Alt+W", "Toggle soft line wrap"),
         Row("Enter", "Start editing commit message"),
         Row("Enter", "Commit changes (or save amend)"),
         Row("Ctrl+Enter", "Amend last commit"),

--- a/src/ui/status_bar.rs
+++ b/src/ui/status_bar.rs
@@ -498,6 +498,17 @@ impl StatusBar {
                             }
                             FocusedPanel::CommitDetail => {
                                 hb.hint_static(" ↑↓ ", key_style, "scroll ", desc_style);
+                                hb.hint(
+                                    " ^⌥w ",
+                                    key_style,
+                                    if app.commit_detail_word_wrap {
+                                        "wrap on "
+                                    } else {
+                                        "wrap off "
+                                    },
+                                    desc_style,
+                                    Action::ToggleCommitDetailWrap,
+                                );
                                 if is_uncommitted {
                                     hb.hint(
                                         " Enter ",

--- a/tests/app_behavior_test.rs
+++ b/tests/app_behavior_test.rs
@@ -11,6 +11,7 @@ use std::path::Path;
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use git2::{Oid, Repository, Signature, Status};
+use ratatui::{buffer::Buffer, layout::Rect, text::Line, widgets::Widget};
 use tempfile::TempDir;
 
 use keifu::action::Action;
@@ -19,6 +20,7 @@ use keifu::app::{
 };
 use keifu::git::GitRepository;
 use keifu::keybindings::map_key_to_action;
+use keifu::ui::{commit_detail::CommitDetailWidget, theme::Theme};
 
 // ── Helpers ─────────────────────────────────────────────────────────
 
@@ -718,6 +720,32 @@ fn commit_detail_wrap_toggle_changes_the_detail_view_state() {
     assert!(app.commit_detail_word_wrap);
     app.handle_action(Action::ToggleCommitDetailWrap).unwrap();
     assert!(!app.commit_detail_word_wrap);
+}
+
+#[test]
+fn commit_detail_wrap_action_reaches_the_rendered_panel() {
+    let (_td, repo) = init_repo();
+    commit_file(repo.repo(), "a.txt", "a", "first");
+    let mut app = make_app(repo);
+    app.focused_panel = FocusedPanel::CommitDetail;
+    app.handle_action(Action::ToggleCommitDetailWrap).unwrap();
+
+    let area = Rect::new(0, 0, 14, 8);
+    let theme = Theme::dark();
+    let mut buffer = Buffer::empty(area);
+    CommitDetailWidget::new(&app, area, &theme, vec![Line::from("abcdefghij klmnop")])
+        .render(area, &mut buffer);
+
+    let mut rendered = String::new();
+    for y in 0..area.height {
+        for x in 0..area.width {
+            rendered.push_str(buffer[(x, y)].symbol());
+        }
+    }
+    assert!(
+        !rendered.contains("klmnop"),
+        "the action's disabled wrap state truncates the long detail line"
+    );
 }
 
 // ── Error toasts (#116) ─────────────────────────────────────────────

--- a/tests/app_behavior_test.rs
+++ b/tests/app_behavior_test.rs
@@ -708,6 +708,18 @@ fn commit_detail_go_to_top_resets_scroll() {
     assert_eq!(app.commit_detail_scroll, 0);
 }
 
+#[test]
+fn commit_detail_wrap_toggle_changes_the_detail_view_state() {
+    let (_td, repo) = init_repo();
+    commit_file(repo.repo(), "a.txt", "a", "first");
+    let mut app = make_app(repo);
+    app.focused_panel = FocusedPanel::CommitDetail;
+
+    assert!(app.commit_detail_word_wrap);
+    app.handle_action(Action::ToggleCommitDetailWrap).unwrap();
+    assert!(!app.commit_detail_word_wrap);
+}
+
 // ── Error toasts (#116) ─────────────────────────────────────────────
 
 #[test]

--- a/tests/keybindings_test.rs
+++ b/tests/keybindings_test.rs
@@ -686,6 +686,13 @@ fn file_diff_mode_scrolling() {
     );
     assert_eq!(map(key(KeyCode::End)), Some(Action::ScrollToBottom));
     assert_eq!(map(key(KeyCode::Char('h'))), Some(Action::ScrollLeft));
+    assert_eq!(
+        map(key_mod(
+            KeyCode::Char('w'),
+            KeyModifiers::CONTROL | KeyModifiers::ALT,
+        )),
+        Some(Action::ToggleDiffWrap),
+    );
     assert_eq!(map(key(KeyCode::Left)), Some(Action::ScrollLeft));
     assert_eq!(map(key(KeyCode::Char('l'))), Some(Action::ScrollRight));
     assert_eq!(map(key(KeyCode::Right)), Some(Action::ScrollRight));

--- a/tests/keybindings_test.rs
+++ b/tests/keybindings_test.rs
@@ -364,6 +364,20 @@ fn commit_detail_ctrl_shortcuts() {
     );
 }
 
+#[test]
+fn ctrl_alt_w_toggles_wrap_only_in_commit_detail() {
+    let chord = key_mod(
+        KeyCode::Char('w'),
+        KeyModifiers::CONTROL | KeyModifiers::ALT,
+    );
+    assert_eq!(
+        map_normal_detail(chord),
+        Some(Action::ToggleCommitDetailWrap)
+    );
+    assert_eq!(map_normal_graph(chord), None);
+    assert_eq!(map_normal_files(chord), None);
+}
+
 // ── Editor mode ─────────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary

Add Ctrl+Alt+W to toggle long-line wrapping in the focused commit-detail panel without coupling it to the file-diff setting.

## Acceptance Criteria

- [ ] With the commit detail panel focused, Ctrl+Alt+W changes a long commit message between wrapped lines and a single truncated line.
- [ ] Ctrl+Alt+W changes only the active view’s wrap preference; the file-diff binding remains independent.

## Test Plan

- `cargo test --test keybindings_test --test app_behavior_test`
- `cargo test long_commit_detail_lines_render_only_when_word_wrap_is_enabled --lib`
- `cargo clippy -- -D warnings`
- Drove the built TUI through its debug server and confirmed the detail panel switches from wrapped rows to a truncated row.

Fixes #139