### PR TITLE
docs: remove stale commit signature status claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ keifu (系譜, /keːɸɯ/) is a terminal UI tool that visualizes Git commit grap
 - Optional pixel-rendered graph lines (continuous VSCode-style curves) on terminals with a graphics protocol (Kitty/iTerm2); falls back to Unicode automatically (`ui.graph_renderer`)
 - Round author avatars per commit (pixel mode) — resolved from GitHub (noreply addresses) or Gravatar, downloaded in the background and disk-cached, with a deterministic colored disc fallback; toggle in the Shift+M menu
 - Commit list with branch/tag labels, compact relative age ("3d", "2w", "5mo"), author, short hash, and message (columns toggle with Shift+M; some fields may be hidden on narrow terminals)
-- Commit detail panel with full message, changed file stats (+/-), and GPG signature status
+- Commit detail panel with full message and changed file stats (+/-)
 - File diff view with syntax highlighting, word-level change emphasis, and hunk-level stage/unstage/discard
 - Files pane: stage/unstage (file, folder, or all), gitignore, archive to `.archive/`, trash untracked files, undo, folder grouping, fuzzy filter, copy path, per-file history
 - Merge-conflict handling: accept ours/theirs, continue/abort a merge, rebase, cherry-pick, or revert

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -325,8 +325,8 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
     };
 
     // Pre-render pass: compute layout metrics that update App scroll state.
-    // Skipped for a hidden commit pane (#116): the layout pass shells out for
-    // signature status and recomputes wrapped lines — work with no consumer.
+    // Skipped for a hidden commit pane (#116): the layout pass recomputes
+    // wrapped lines — work with no consumer.
     let commit_lines = if commit_area.is_empty() {
         Vec::new()
     } else {

--- a/tests/app_behavior_test.rs
+++ b/tests/app_behavior_test.rs
@@ -20,7 +20,10 @@ use keifu::app::{
 };
 use keifu::git::GitRepository;
 use keifu::keybindings::map_key_to_action;
-use keifu::ui::{commit_detail::CommitDetailWidget, theme::Theme};
+use keifu::ui::{
+    commit_detail::{compute_commit_detail_layout, CommitDetailWidget},
+    theme::Theme,
+};
 
 // ── Helpers ─────────────────────────────────────────────────────────
 
@@ -745,6 +748,29 @@ fn commit_detail_wrap_action_reaches_the_rendered_panel() {
     assert!(
         !rendered.contains("klmnop"),
         "the action's disabled wrap state truncates the long detail line"
+    );
+}
+
+#[test]
+fn selected_commit_detail_omits_signature_status() {
+    let (_td, repo) = init_repo();
+    commit_file(repo.repo(), "a.txt", "a", "commit message");
+    let mut app = make_app(repo);
+    let theme = Theme::dark();
+
+    let lines = compute_commit_detail_layout(&mut app, Rect::new(0, 0, 80, 20), &theme);
+    let rendered: String = lines
+        .iter()
+        .flat_map(|line| line.spans.iter())
+        .map(|span| span.content.as_ref())
+        .collect();
+
+    assert!(rendered.contains("Author: Test User <test@example.com>"));
+    assert!(rendered.contains("Date:   "));
+    assert!(rendered.contains("commit message"));
+    assert!(
+        !rendered.contains("Sig:"),
+        "selected commit details must not display signature status"
     );
 }
 

--- a/tests/documentation_regression_test.rs
+++ b/tests/documentation_regression_test.rs
@@ -1,0 +1,11 @@
+//! Regression checks for user-facing capability claims.
+
+#[test]
+fn readme_does_not_advertise_removed_commit_signature_status() {
+    let readme = include_str!("../README.md");
+
+    assert!(
+        !readme.contains("GPG signature status"),
+        "README must not advertise signature status after it was removed from commit details"
+    );
+}


### PR DESCRIPTION
Fixes #119

The code removal from #119 is already present in `chong-dev`; this follow-up removes its remaining public/stale references and adds regression coverage at the commit-detail rendering seam.

## Acceptance Criteria
- [ ] When a commit is selected, the commit-detail pane shows its remaining metadata and message without any `Sig:` line or signature-status value.
- [ ] Selecting commits of different signature states does not display signature status in the commit-detail pane.

## Validation
- `env -u GIT_AUTHOR_NAME -u GIT_COMMITTER_NAME -u GIT_AUTHOR_EMAIL -u GIT_COMMITTER_EMAIL cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- Debug-server rendered dump of a selected commit detail (Author, Date, message; no `Sig:` line).