### PR TITLE
fix: brighten trunk branch color

### DIFF
--- a/src/graph/colors.rs
+++ b/src/graph/colors.rs
@@ -14,7 +14,7 @@ pub const LANE_COLORS: [Color; 11] = [
     Color::LightGreen,
     Color::LightMagenta,
     Color::LightYellow,
-    Color::LightBlue, // Main branch
+    MAIN_BRANCH_DISPLAY_COLOR, // Main branch
     Color::LightRed,
 ];
 
@@ -28,6 +28,9 @@ pub const UNCOMMITTED_COLOR_INDEX: usize = usize::MAX;
 /// dedicated theme entry in both renderers.
 pub const SQUASH_LINK_COLOR_INDEX: usize = usize::MAX - 1;
 
+/// Bright blue used for the trunk branch in dark terminals.
+pub const MAIN_BRANCH_DISPLAY_COLOR: Color = Color::Rgb(88, 166, 255);
+
 /// Get a color from a color index
 pub fn get_color_by_index(color_index: usize) -> Color {
     if color_index == UNCOMMITTED_COLOR_INDEX || color_index == SQUASH_LINK_COLOR_INDEX {
@@ -36,8 +39,8 @@ pub fn get_color_by_index(color_index: usize) -> Color {
     LANE_COLORS[color_index % LANE_COLORS.len()]
 }
 
-/// Main branch color (light blue)
-pub const MAIN_BRANCH_COLOR: usize = 9; // Color::LightBlue
+/// Main branch color index
+pub const MAIN_BRANCH_COLOR: usize = 9; // MAIN_BRANCH_DISPLAY_COLOR
 
 /// Color assignment to vary colors when lanes are reused
 #[derive(Debug)]

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -225,7 +225,7 @@ impl Theme {
                 Color::LightGreen,
                 Color::LightMagenta,
                 Color::LightYellow,
-                Color::LightBlue, // main branch
+                crate::graph::colors::MAIN_BRANCH_DISPLAY_COLOR, // main branch
                 Color::LightRed,
             ],
             uncommitted_color: Color::DarkGray,

--- a/tests/theme_test.rs
+++ b/tests/theme_test.rs
@@ -1,0 +1,22 @@
+use keifu::graph::colors::{get_color_by_index, MAIN_BRANCH_COLOR};
+use keifu::ui::theme::Theme;
+use ratatui::style::Color;
+
+#[test]
+fn dark_theme_renders_the_trunk_as_bright_blue() {
+    assert_eq!(
+        Theme::dark().lane_color(MAIN_BRANCH_COLOR),
+        Color::Rgb(88, 166, 255)
+    );
+}
+
+#[test]
+fn light_theme_renders_the_trunk_as_blue() {
+    assert_eq!(Theme::light().lane_color(MAIN_BRANCH_COLOR), Color::Blue);
+}
+
+#[test]
+fn changing_the_trunk_color_does_not_change_sentinel_colors() {
+    assert_eq!(get_color_by_index(usize::MAX), Color::DarkGray);
+    assert_eq!(get_color_by_index(usize::MAX - 1), Color::DarkGray);
+}


### PR DESCRIPTION
Fixes #131\n\n## Summary\n- Replace the dark-theme trunk lane's indigo-like ANSI LightBlue with explicit bright blue Rgb(88, 166, 255).\n- Share the bright-blue value with the graph palette while preserving the light-theme blue and sentinel colors.\n\n## Acceptance Criteria\n- [ ] The trunk lane rendered by the dark-theme graph uses bright blue instead of indigo-like blue.\n- [ ] The light-theme graph keeps the trunk lane prominent blue.\n- [ ] Other lane colors and reserved sentinel colors retain their existing behavior.\n\n## Test Plan\n- cargo test --test theme_test (3 passed)\n- cargo clippy -- -D warnings (passed)\n- Real-app debug-server dump verified the graph renders on this branch.\n- cargo test ran 915 unit tests and integration suites; one unrelated environment-sensitive test failed because this runner has a configured Git identity: commit_without_configured_user_maps_to_friendly_error.\n\nAdversarial review: PASS.\n