### PR TITLE
fix: make l pull

### DIFF
--- a/.harness/test-cmd
+++ b/.harness/test-cmd
@@ -1,1 +1,1 @@
-cargo test --test keybindings_test graph_mode_l_pulls -- --exact; test $? -eq 0
+cargo test --test issue_158_keybinding_test graph_mode_l_pulls -- --exact; test $? -eq 0

--- a/.harness/test-cmd
+++ b/.harness/test-cmd
@@ -1,0 +1,1 @@
+cargo test --test keybindings_test graph_mode_l_pulls -- --exact; test $? -eq 0

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Panels: **Graph** → **Files** → **Commit Detail**, cycled with `←`/`→` o
 | `b` | Create branch at selected commit |
 | `d` | Delete branch (local or remote, behind confirm) |
 | `f` | Fetch (resolves the remote from upstream; prompts if ambiguous) |
-| `p` | Pull (fetch + integrate; honors `pull.rebase`) |
+| `l` | Pull (fetch + integrate; honors `pull.rebase`) |
 | `Shift+P` | Push current branch (publishes with `-u` if it has no upstream) |
 | `Shift+B` | Branch filter — choose which branches' commits are shown; type to filter by name, or `@name` to filter by branch author (then `Ctrl+O` hides that whole subset) |
 | `Shift+O` | Show/hide remote-only branches — hides remote refs with no matching local branch, and their exclusive commits; persists |

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -94,19 +94,61 @@ what flushes the exit-time `perf summary` to the log.
 For a graph-panel keybinding that starts an asynchronous operation, query the
 state before and immediately after injecting the key. The focused panel and
 selection should remain unchanged, while the operation-specific state flag
-should become active. For example, this verifies that lowercase `l` routes to
-Pull rather than graph navigation:
+should become active. Use a clean local fixture with a configured upstream so
+the completion result is deterministic. This verifies that lowercase `l`
+routes to Pull rather than graph navigation:
 
 ```bash
-nohup script -qec "keifu --debug-listen 127.0.0.1:7169" /dev/null &
-printf '%s\n' '{"cmd":"state"}' '{"cmd":"keys","keys":"l"}' '{"cmd":"state"}' \
-  | nc -q1 127.0.0.1 7169
-printf '%s\n' '{"cmd":"keys","keys":"<c-q>"}' | nc -q1 127.0.0.1 7169
+set -euo pipefail
+
+tmp_dir=$(mktemp -d /tmp/keifu-debug.XXXXXX)
+git init -q -b main "$tmp_dir/seed"
+git -C "$tmp_dir/seed" config user.name Harness
+git -C "$tmp_dir/seed" config user.email harness@example.com
+git -C "$tmp_dir/seed" commit --allow-empty -qm initial
+git clone -q --bare "$tmp_dir/seed" "$tmp_dir/remote.git"
+git clone -q "$tmp_dir/remote.git" "$tmp_dir/clone"
+
+(cd "$tmp_dir/clone" && nohup script -qec \
+  "keifu --debug-listen 127.0.0.1:7169" /tmp/keifu-debug.session \
+  >/tmp/keifu-debug.pty 2>&1 &)
+for _ in $(seq 30); do
+  nc -z 127.0.0.1 7169 2>/dev/null && break
+  sleep 1
+done
+nc -z 127.0.0.1 7169
+
+before=$(printf '%s\n' '{"cmd":"state"}' | nc -q1 127.0.0.1 7169)
+immediate=$(printf '%s\n' '{"cmd":"keys","keys":"l"}' '{"cmd":"state"}' \
+  | nc -q1 127.0.0.1 7169 | tail -n 1)
+before_index=$(jq -r '.selected_index' <<<"$before")
+after_index=$(jq -r '.selected_index' <<<"$immediate")
+jq -e '(.mode == "normal" and .focused_panel == "graph")' <<<"$before" >/dev/null
+jq -e '(.mode == "normal" and .focused_panel == "graph")' <<<"$immediate" >/dev/null
+test "$before_index" = "$after_index"
+# A very fast local pull may already be complete in the immediate response;
+# the final state and rendered result below are the completion assertion.
+immediate_started=$(jq -r '.is_pulling' <<<"$immediate")
+
+for _ in $(seq 30); do
+  settled=$(printf '%s\n' '{"cmd":"state"}' | nc -q1 127.0.0.1 7169)
+  jq -e '.is_pulling == false' <<<"$settled" >/dev/null && break
+  sleep 1
+done
+jq -e '.is_pulling == false' <<<"$settled" >/dev/null
+screen=$(printf '%s\n' '{"cmd":"dump","width":120,"height":35}' \
+  | nc -q1 127.0.0.1 7169 | jq -r '.screen')
+grep -Fq 'Pulled' <<<"$screen"
+printf '%s\n' '{"cmd":"keys","keys":"<c-q>"}' \
+  | nc -q1 127.0.0.1 7169 >/dev/null
+rm -rf "$tmp_dir"
 ```
 
-The post-key state should still report `mode: "normal"`,
-`focused_panel: "graph"`, and the same `selected_index`, while
-`is_pulling` is `true` (or the operation has already completed).
+The assertions prove startup readiness, Normal + Graph focus before and after
+the key, unchanged selection, completion (`is_pulling == false`), and the
+observable successful Pull result (`Pulled` in the rendered screen). The
+immediate response also records whether the async operation was still active
+(`is_pulling == true`) or completed within the request round-trip.
 
 ## Pixel-graph debugging (headless PNG rendering)
 

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -101,6 +101,10 @@ routes to Pull rather than graph navigation:
 ```bash
 set -euo pipefail
 
+cargo build
+keifu_bin="$PWD/target/debug/keifu"
+test -x "$keifu_bin"
+
 tmp_dir=$(mktemp -d /tmp/keifu-debug.XXXXXX)
 git init -q -b main "$tmp_dir/seed"
 git -C "$tmp_dir/seed" config user.name Harness
@@ -110,7 +114,7 @@ git clone -q --bare "$tmp_dir/seed" "$tmp_dir/remote.git"
 git clone -q "$tmp_dir/remote.git" "$tmp_dir/clone"
 
 (cd "$tmp_dir/clone" && nohup script -qec \
-  "keifu --debug-listen 127.0.0.1:7169" /tmp/keifu-debug.session \
+  "$keifu_bin --debug-listen 127.0.0.1:7169" /tmp/keifu-debug.session \
   >/tmp/keifu-debug.pty 2>&1 &)
 for _ in $(seq 30); do
   nc -z 127.0.0.1 7169 2>/dev/null && break

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -89,6 +89,25 @@ printf '%s\n' '{"cmd":"keys","keys":"<c-q>"}' | nc -q1 127.0.0.1 7167  # Ctrl+Q 
 once nothing is pending to dismiss. Quitting cleanly (not a killed process) is
 what flushes the exit-time `perf summary` to the log.
 
+### Verifying a graph action in the live app
+
+For a graph-panel keybinding that starts an asynchronous operation, query the
+state before and immediately after injecting the key. The focused panel and
+selection should remain unchanged, while the operation-specific state flag
+should become active. For example, this verifies that lowercase `l` routes to
+Pull rather than graph navigation:
+
+```bash
+nohup script -qec "keifu --debug-listen 127.0.0.1:7169" /dev/null &
+printf '%s\n' '{"cmd":"state"}' '{"cmd":"keys","keys":"l"}' '{"cmd":"state"}' \
+  | nc -q1 127.0.0.1 7169
+printf '%s\n' '{"cmd":"keys","keys":"<c-q>"}' | nc -q1 127.0.0.1 7169
+```
+
+The post-key state should still report `mode: "normal"`,
+`focused_panel: "graph"`, and the same `selected_index`, while
+`is_pulling` is `true` (or the operation has already completed).
+
 ## Pixel-graph debugging (headless PNG rendering)
 
 The debug server cannot exercise graphics-protocol output. To reproduce

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -381,8 +381,8 @@ fn map_graph_mode(key: KeyEvent) -> Option<Action> {
         (KeyModifiers::NONE, KeyCode::Char('b')) => Some(Action::CreateBranch),
         (KeyModifiers::NONE, KeyCode::Char('d')) => Some(Action::DeleteBranch),
         (KeyModifiers::NONE, KeyCode::Char('f')) => Some(Action::Fetch),
-        // Pull / push pairing: lowercase pull, Shift+P push.
-        (KeyModifiers::NONE, KeyCode::Char('p')) => Some(Action::Pull),
+        // Pull / push pairing: lowercase l pulls, Shift+P pushes.
+        (KeyModifiers::NONE, KeyCode::Char('l')) => Some(Action::Pull),
         (KeyModifiers::SHIFT, KeyCode::Char('P')) => Some(Action::Push),
 
         // Space opens file diff for quick access

--- a/src/keybindings.rs
+++ b/src/keybindings.rs
@@ -1187,11 +1187,11 @@ mod tests {
     #[test]
     fn release_events_produce_no_action() {
         // With keyboard enhancement on, the terminal echoes a Release for every
-        // key. It must not re-fire the binding (here: 'p' → Pull in the graph).
+        // key. It must not re-fire the binding (here: 'l' → Pull in the graph).
         let press =
-            KeyEvent::new_with_kind(KeyCode::Char('p'), KeyModifiers::NONE, KeyEventKind::Press);
+            KeyEvent::new_with_kind(KeyCode::Char('l'), KeyModifiers::NONE, KeyEventKind::Press);
         let release = KeyEvent::new_with_kind(
-            KeyCode::Char('p'),
+            KeyCode::Char('l'),
             KeyModifiers::NONE,
             KeyEventKind::Release,
         );

--- a/tests/issue_158_keybinding_test.rs
+++ b/tests/issue_158_keybinding_test.rs
@@ -1,0 +1,20 @@
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use keifu::action::Action;
+use keifu::app::{AppMode, FocusedPanel};
+use keifu::keybindings::map_key_to_action;
+
+#[test]
+fn graph_mode_l_pulls() {
+    let key = KeyEvent::new(KeyCode::Char('l'), KeyModifiers::NONE);
+    assert_eq!(
+        map_key_to_action(
+            key,
+            &AppMode::Normal,
+            FocusedPanel::Graph,
+            false,
+            false,
+            false,
+        ),
+        Some(Action::Pull)
+    );
+}

--- a/tests/keybindings_test.rs
+++ b/tests/keybindings_test.rs
@@ -247,15 +247,7 @@ fn graph_mode_branch_navigation() {
         Some(Action::PrevBranch)
     );
     assert_eq!(map_normal_graph(key(KeyCode::Char('h'))), None);
-    assert_eq!(map_normal_graph(key(KeyCode::Char('l'))), Some(Action::Pull));
-}
-
-#[test]
-fn graph_mode_l_pulls() {
-    assert_eq!(
-        map_normal_graph(key(KeyCode::Char('l'))),
-        Some(Action::Pull)
-    );
+    assert_eq!(map_normal_graph(key(KeyCode::Char('l'))), None);
 }
 
 #[test]

--- a/tests/keybindings_test.rs
+++ b/tests/keybindings_test.rs
@@ -251,6 +251,14 @@ fn graph_mode_branch_navigation() {
 }
 
 #[test]
+fn graph_mode_l_pulls() {
+    assert_eq!(
+        map_normal_graph(key(KeyCode::Char('l'))),
+        Some(Action::Pull)
+    );
+}
+
+#[test]
 fn graph_mode_actions() {
     assert_eq!(
         map_normal_graph(key(KeyCode::Enter)),

--- a/tests/keybindings_test.rs
+++ b/tests/keybindings_test.rs
@@ -247,7 +247,7 @@ fn graph_mode_branch_navigation() {
         Some(Action::PrevBranch)
     );
     assert_eq!(map_normal_graph(key(KeyCode::Char('h'))), None);
-    assert_eq!(map_normal_graph(key(KeyCode::Char('l'))), None);
+    assert_eq!(map_normal_graph(key(KeyCode::Char('l'))), Some(Action::Pull));
 }
 
 #[test]

--- a/tests/keybindings_test.rs
+++ b/tests/keybindings_test.rs
@@ -247,7 +247,10 @@ fn graph_mode_branch_navigation() {
         Some(Action::PrevBranch)
     );
     assert_eq!(map_normal_graph(key(KeyCode::Char('h'))), None);
-    assert_eq!(map_normal_graph(key(KeyCode::Char('l'))), Some(Action::Pull));
+    assert_eq!(
+        map_normal_graph(key(KeyCode::Char('l'))),
+        Some(Action::Pull)
+    );
 }
 
 #[test]


### PR DESCRIPTION
Fixes #158

## Acceptance Criteria
- [ ] In Normal mode with the graph panel focused, pressing lowercase `l` dispatches the Pull action.
- [ ] In the graph panel, pressing lowercase `l` no longer dispatches branch navigation or any other action.

## Test Plan
- Added `graph_mode_l_pulls` regression coverage at the keybinding dispatch seam.
- Targeted: `cargo test --test issue_158_keybinding_test graph_mode_l_pulls -- --exact`
- Full suite: `env -u GIT_AUTHOR_NAME -u GIT_COMMITTER_NAME GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null cargo test`
- Lint: `cargo clippy --all-targets --all-features -- -D warnings`

The red test was confirmed failing before the remapping; it passes with this change.