### PR TITLE
chore: update plist to 1.10 to pull quick-xml 0.41 (RUSTSEC-2026-0194/0195)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1260,9 +1260,9 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plist"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64",
  "indexmap",
@@ -1325,9 +1325,9 @@ checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]


### PR DESCRIPTION
## Problem

Every PR's Security Audit CI check (rustsec/audit-check) fails because
transitive dependency `quick-xml 0.38.4` is affected by two advisories:

- RUSTSEC-2026-0194
- RUSTSEC-2026-0195

Both are fixed in `quick-xml >= 0.41.0`.

## Dependency chain

`keifu -> syntect 5.3.0 -> plist 1.8.0 -> quick-xml ^0.38`

`plist 1.10.0` requires `quick-xml ^0.41.0`.

## Fix

Lockfile-only update: `cargo update -p plist`, which pulls
`plist 1.8.0 -> 1.10.0` and transitively `quick-xml 0.38.4 -> 0.41.0`.
No `Cargo.toml` or source changes are needed — only `Cargo.lock`
(4 lines) is touched.

## Verification

- `cargo check`: passes.
- `cargo audit`: RUSTSEC-2026-0194 and RUSTSEC-2026-0195 no longer
  appear. Remaining warnings (paste, yaml-rust unmaintained; anyhow,
  git2, lru unsound) are pre-existing, unrelated, and do not fail CI.