### PR TITLE
Fix duplicate squash merge connectors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ Constraints whose violation has caused real bugs — the code shows *what*, this
 - **Merged-lane dimming yields to the selected trace.** A selected merged branch must keep its complete path, including its merge arc into the trunk, visible in both Unicode and pixel graph renderers; unrelated merged work remains dimmed.
 - **Settings go through the pure registry** in `src/settings.rs` (no `App` dependency). State-only settings persist via `UiState` to `state.toml`; config-file settings rewrite only touched keys through `toml_edit` so user comments survive.
 - **The unicode and pixel dim/render paths are deliberately parallel implementations** (see comments in `ui/graph_view/`). Do not unify them.
+- **Squash-merge connector identity is its endpoint pair, not a branch name.** Local and remote refs can alias the same tip and target; resolve them through `SquashMergeLine::from_branch_targets` so the graph draws one connector.
 - **Clipboard uses shell tools with an OSC 52 fallback** — no clipboard crate (avoids openssl-sys build breakage).
 
 Fix root causes, not symptoms. Avoid band-aids like stopPropagation, setTimeout, or flags to mask bugs.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -227,6 +227,15 @@ the dot it belongs to. Because `transition_curves` is pure over the cells,
 drawing stays a deterministic function of the `RowSpec`, so the protocol cache
 stays correct. Unicode mode is unchanged (box glyphs can't curve).
 
+**Squash connector identity follows endpoints (2026-08-01, #156).**
+`SquashMergeLine` models the visual relationship as `(branch_tip,
+squash_commit)`, independent of the ref name that discovered it. Local and
+remote-tracking refs can resolve to the same endpoint pair, so
+`from_branch_targets` canonicalizes and deduplicates those aliases before graph
+layout. `inject_squash_links` repeats that normalization at its boundary to
+keep direct callers idempotent: supplying the same relationship twice produces
+the same cells, edge metadata, and graph width as supplying it once.
+
 **Squash link joins the uncommitted band via `TeeDown` (2026-07-22, #115).**
 When HEAD sits on a squash-merge target with uncommitted changes, two layout
 overlays land on the same row: the uncommitted node's horizontal landing band

--- a/examples/render_rows.rs
+++ b/examples/render_rows.rs
@@ -3,7 +3,7 @@
 //! Usage: KEIFU_UNCOMMITTED=<n> cargo run --example render_rows -- <repo> <start> <end> <out.png>
 
 use image::RgbaImage;
-use keifu::git::graph::{build_graph, CellType, GraphNode};
+use keifu::git::graph::{build_graph, CellType, GraphNode, SquashMergeLine};
 use keifu::git::GitRepository;
 use keifu::ui::graph_pixels::{build_row_spec, rasterize_row, NeighborRow};
 use keifu::ui::theme::Theme;
@@ -36,7 +36,7 @@ fn main() {
         .and_then(|v| v.parse::<usize>().ok())
         .map(Some);
     // Real squash links, like the app's dim-mode classifier produces.
-    let squash_links: Vec<(git2::Oid, git2::Oid)> = keifu::git::merged::base_branch(&branches)
+    let squash_lines = keifu::git::merged::base_branch(&branches)
         .map(|base| {
             let (_, targets) = keifu::git::merged::classify_merged_branches_with_targets(
                 repo.repo(),
@@ -45,16 +45,10 @@ fn main() {
                 &base.name.clone(),
                 &Default::default(),
             );
-            targets
-                .iter()
-                .filter_map(|(name, &target)| {
-                    let tip = branches.iter().find(|b| &b.name == name)?.tip_oid;
-                    Some((tip, target))
-                })
-                .collect()
+            SquashMergeLine::from_branch_targets(&branches, &targets)
         })
         .unwrap_or_default();
-    eprintln!("squash links: {}", squash_links.len());
+    eprintln!("squash links: {}", squash_lines.len());
     let layout = build_graph(
         &commits,
         &branches,
@@ -62,7 +56,7 @@ fn main() {
         &stashes,
         uncommitted,
         head_oid,
-        &squash_links,
+        &squash_lines,
     );
 
     // Fold connectors into the following commit row, like `fold_rows`.

--- a/src/app/init.rs
+++ b/src/app/init.rs
@@ -150,14 +150,8 @@ impl App {
         // both-endpoints-loaded guard makes the links inert there; in the default
         // dim mode `squash_targets` fills in with the async classifier and a later
         // rebuild draws them.
-        let squash_links: Vec<(git2::Oid, git2::Oid)> = if config.ui.squash_link_lines {
-            squash_targets
-                .iter()
-                .filter_map(|(name, &target)| {
-                    let tip = branches.iter().find(|b| &b.name == name)?.tip_oid;
-                    Some((tip, target))
-                })
-                .collect()
+        let squash_lines = if config.ui.squash_link_lines {
+            SquashMergeLine::from_branch_targets(&branches, &squash_targets)
         } else {
             Vec::new()
         };
@@ -168,7 +162,7 @@ impl App {
             &stashes,
             uncommitted_count,
             head_commit_oid,
-            &squash_links,
+            &squash_lines,
         );
 
         phase!("build_graph");

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -13,7 +13,7 @@ use crate::{
     files_pane_state::{section_of, FilesPaneState},
     git::{
         build_graph, extract_hunk_from_working_tree,
-        graph::GraphLayout,
+        graph::{GraphLayout, SquashMergeLine},
         operations::{
             abort_operation, accept_ours, accept_theirs, add_tag, apply_patch_cached,
             apply_patch_cached_reverse, apply_patch_worktree_reverse, checkout_branch,
@@ -1812,23 +1812,16 @@ impl App {
         self.merged.classify.maybe_start(input);
     }
 
-    /// The squash-link edges to feed [`build_graph`]: `(branch_tip, squash_commit)`
+    /// The unique squash-merge lines to feed [`build_graph`]
     /// for each squash-merged branch, but only when the `squash_link_lines` option
     /// is on. Empty (option off) leaves the layout byte-identical. Each branch
     /// name is resolved to its current tip OID; `build_graph` further guards that
     /// both endpoints are loaded before drawing anything (issue #81).
-    pub(crate) fn squash_link_edges(&self) -> Vec<(git2::Oid, git2::Oid)> {
+    pub(crate) fn squash_merge_lines(&self) -> Vec<SquashMergeLine> {
         if !self.config.ui.squash_link_lines {
             return Vec::new();
         }
-        self.merged
-            .squash_targets
-            .iter()
-            .filter_map(|(name, &target)| {
-                let tip = self.branches.iter().find(|b| &b.name == name)?.tip_oid;
-                Some((tip, target))
-            })
-            .collect()
+        SquashMergeLine::from_branch_targets(&self.branches, &self.merged.squash_targets)
     }
 
     /// Recompute the set of base-update ("back-merge") commits (issue #55) from

--- a/src/app/refresh.rs
+++ b/src/app/refresh.rs
@@ -396,7 +396,7 @@ impl App {
         self.all_commits_loaded = self.commits.len() < self.commit_load_limit;
         let tags = self.repo.get_tags();
         let head_commit_oid = self.repo.head_oid();
-        let squash_links = self.squash_link_edges();
+        let squash_lines = self.squash_merge_lines();
         self.graph_layout = build_graph(
             &self.commits,
             &visible_branches,
@@ -404,7 +404,7 @@ impl App {
             &stashes,
             uncommitted_count,
             head_commit_oid,
-            &squash_links,
+            &squash_lines,
         );
         // Invalidate the pixel-graph spec cache: the layout changed.
         self.graph_generation = self.graph_generation.wrapping_add(1);

--- a/src/git/graph.rs
+++ b/src/git/graph.rs
@@ -2702,6 +2702,41 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn squash_link_duplicate_relationship_is_idempotent() {
+        // Local and remote refs commonly name the same surviving branch tip.
+        // Both classifications describe one user-visible squash relationship.
+        let (commits, [s, f1, _t, _z]) = squash_link_fixture();
+        let single = build_graph(&commits, &[], &[], &[], None, None, &[(f1, s)]);
+        let duplicate = build_graph(
+            &commits,
+            &[],
+            &[],
+            &[],
+            None,
+            None,
+            &[(f1, s), (f1, s)],
+        );
+
+        assert_eq!(
+            duplicate.max_lane, single.max_lane,
+            "repeating one squash relationship must not widen the graph"
+        );
+        assert_eq!(duplicate.nodes.len(), single.nodes.len());
+        for (row, (actual, expected)) in duplicate
+            .nodes
+            .iter()
+            .zip(&single.nodes)
+            .enumerate()
+        {
+            assert_eq!(
+                actual.cells, expected.cells,
+                "row {row} must contain exactly the single continuous connector"
+            );
+            assert_eq!(actual.cell_oids, expected.cell_oids);
+        }
+    }
+
     /// #115 repro shape: HEAD sits ON the squash commit `S` with uncommitted
     /// changes. Lanes 0 and 1 are busy above HEAD (children X, Y of S), so the
     /// uncommitted node lands on a farther lane and its horizontal band crosses

--- a/src/git/graph.rs
+++ b/src/git/graph.rs
@@ -56,6 +56,25 @@ pub type CellEdge = (Oid, Oid);
 /// [`GraphNode::cell_oids`].
 pub type CellOids = (Option<CellEdge>, Option<CellEdge>);
 
+/// A visual connector between a squash-merged branch tip and the commit that
+/// landed it. Branch names are deliberately absent: local and remote refs may
+/// name the same relationship, while the graph should draw that relationship
+/// only once.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SquashMergeLine {
+    pub branch_tip: Oid,
+    pub squash_commit: Oid,
+}
+
+impl SquashMergeLine {
+    pub fn new(branch_tip: Oid, squash_commit: Oid) -> Self {
+        Self {
+            branch_tip,
+            squash_commit,
+        }
+    }
+}
+
 impl GraphNode {
     /// A merge commit (2+ parents). Stash commits are excluded — their extra
     /// parents are truncated to one at load time, so they never count as merges.

--- a/src/git/graph.rs
+++ b/src/git/graph.rs
@@ -73,6 +73,34 @@ impl SquashMergeLine {
             squash_commit,
         }
     }
+
+    /// Resolve branch-name classifications into unique visual relationships.
+    /// A local ref and its remote-tracking ref can share the same tip and
+    /// squash target; those aliases still describe one line on the graph.
+    pub fn from_branch_targets(
+        branches: &[BranchInfo],
+        targets: &HashMap<String, Oid>,
+    ) -> Vec<Self> {
+        let mut lines: Vec<Self> = targets
+            .iter()
+            .filter_map(|(name, &squash_commit)| {
+                let branch_tip = branches.iter().find(|b| &b.name == name)?.tip_oid;
+                Some(Self::new(branch_tip, squash_commit))
+            })
+            .collect();
+        canonicalize_squash_lines(&mut lines);
+        lines
+    }
+}
+
+fn canonicalize_squash_lines(lines: &mut Vec<SquashMergeLine>) {
+    lines.sort_unstable_by(|a, b| {
+        a.branch_tip
+            .as_bytes()
+            .cmp(b.branch_tip.as_bytes())
+            .then_with(|| a.squash_commit.as_bytes().cmp(b.squash_commit.as_bytes()))
+    });
+    lines.dedup();
 }
 
 impl GraphNode {
@@ -199,7 +227,7 @@ fn head_first_parent_line(
 /// count is unavailable (e.g. collapsed untracked directories).
 /// head_commit_oid: The OID of the commit that HEAD points to (for uncommitted
 /// changes and for anchoring HEAD's first-parent line to lane 0)
-/// squash_links: `(branch_tip, squash_commit)` pairs to draw a muted-grey link
+/// squash_lines: endpoint relationships to draw as muted-grey connectors
 /// line between (issue #81). Empty (the option off) leaves the layout
 /// byte-identical to before — the links are a pure post-pass overlay; see
 /// [`inject_squash_links`]. A pair whose endpoints aren't both loaded is skipped.
@@ -210,7 +238,7 @@ pub fn build_graph(
     stashes: &[super::repository::StashInfo],
     uncommitted_count: Option<Option<usize>>,
     head_commit_oid: Option<Oid>,
-    squash_links: &[(Oid, Oid)],
+    squash_lines: &[SquashMergeLine],
 ) -> GraphLayout {
     // Map stash oid -> short label like "stash@{0}"
     let stash_oid_labels: HashMap<Oid, String> = stashes
@@ -690,7 +718,7 @@ pub fn build_graph(
     // Overlay squash-merge link lines last, once every row (including the
     // uncommitted node) is in place, so endpoints are resolved against the final
     // row set (issue #81). A no-op when `squash_links` is empty.
-    inject_squash_links(&mut nodes, &mut max_lane, squash_links);
+    inject_squash_links(&mut nodes, &mut max_lane, squash_lines);
 
     GraphLayout { nodes, max_lane }
 }
@@ -876,8 +904,8 @@ fn insert_uncommitted_node(
 /// than the branch tip it landed (it is created at merge time), so the link may
 /// run in either direction between its two rows. This overlay connects the rows
 /// regardless of their order.
-fn inject_squash_links(nodes: &mut [GraphNode], max_lane: &mut usize, links: &[(Oid, Oid)]) {
-    if links.is_empty() {
+fn inject_squash_links(nodes: &mut [GraphNode], max_lane: &mut usize, lines: &[SquashMergeLine]) {
+    if lines.is_empty() {
         return; // option off (or nothing to link) → layout untouched.
     }
     // oid -> row index, for commit-carrying rows only. Row indices are stable —
@@ -888,10 +916,18 @@ fn inject_squash_links(nodes: &mut [GraphNode], max_lane: &mut usize, links: &[(
         .filter_map(|(i, n)| n.commit.as_ref().map(|c| (c.oid, i)))
         .collect();
 
-    for &(tip, target) in links {
+    // Treat the endpoint pair as the identity of a visual line. This final
+    // normalization keeps layout construction idempotent even if a future
+    // caller bypasses `from_branch_targets` and supplies aliases directly.
+    let mut unique_lines = lines.to_vec();
+    canonicalize_squash_lines(&mut unique_lines);
+    for line in unique_lines {
         // Guard: only draw when BOTH endpoints are loaded (e.g. the branch tip is
         // filtered out when merged branches are hidden, or history is truncated).
-        if let (Some(&r1), Some(&r2)) = (oid_row.get(&tip), oid_row.get(&target)) {
+        if let (Some(&r1), Some(&r2)) = (
+            oid_row.get(&line.branch_tip),
+            oid_row.get(&line.squash_commit),
+        ) {
             if r1 != r2 {
                 draw_squash_link(nodes, max_lane, r1, r2);
             }
@@ -2508,7 +2544,15 @@ mod tests {
     fn squash_link_draws_grey_and_preserves_real_cells() {
         let (commits, [s, f1, _t, _z]) = squash_link_fixture();
         let base = build_graph(&commits, &[], &[], &[], None, None, &[]);
-        let linked = build_graph(&commits, &[], &[], &[], None, None, &[(f1, s)]);
+        let linked = build_graph(
+            &commits,
+            &[],
+            &[],
+            &[],
+            None,
+            None,
+            &[SquashMergeLine::new(f1, s)],
+        );
 
         // The link introduces grey cells; the baseline had none.
         assert!(!has_squash_grey(&base));
@@ -2542,7 +2586,15 @@ mod tests {
     #[test]
     fn squash_link_cells_are_never_traced() {
         let (commits, [s, f1, _t, _z]) = squash_link_fixture();
-        let layout = build_graph(&commits, &[], &[], &[], None, None, &[(f1, s)]);
+        let layout = build_graph(
+            &commits,
+            &[],
+            &[],
+            &[],
+            None,
+            None,
+            &[SquashMergeLine::new(f1, s)],
+        );
 
         // Tracing either the feature or the trunk must leave the grey link dim.
         for sel in [f1, s] {
@@ -2606,7 +2658,15 @@ mod tests {
             ci(b, vec![]),  // shared base
         ];
         let base = build_graph(&commits, &[], &[], &[], None, None, &[]);
-        let linked = build_graph(&commits, &[], &[], &[], None, None, &[(f, s)]);
+        let linked = build_graph(
+            &commits,
+            &[],
+            &[],
+            &[],
+            None,
+            None,
+            &[SquashMergeLine::new(f, s)],
+        );
 
         let sr = row_of(&linked, s);
         let fr = row_of(&linked, f);
@@ -2680,7 +2740,15 @@ mod tests {
         // detour. When the connector rides an endpoint's own lane, that endpoint
         // is anchored by its dot and carries no separate curve.)
         let (commits, [s, f1, _t, _z]) = squash_link_fixture();
-        let layout = build_graph(&commits, &[], &[], &[], None, None, &[(f1, s)]);
+        let layout = build_graph(
+            &commits,
+            &[],
+            &[],
+            &[],
+            None,
+            None,
+            &[SquashMergeLine::new(f1, s)],
+        );
 
         let sr = row_of(&layout, s);
         let fr = row_of(&layout, f1);
@@ -2707,7 +2775,15 @@ mod tests {
         // Local and remote refs commonly name the same surviving branch tip.
         // Both classifications describe one user-visible squash relationship.
         let (commits, [s, f1, _t, _z]) = squash_link_fixture();
-        let single = build_graph(&commits, &[], &[], &[], None, None, &[(f1, s)]);
+        let single = build_graph(
+            &commits,
+            &[],
+            &[],
+            &[],
+            None,
+            None,
+            &[SquashMergeLine::new(f1, s)],
+        );
         let duplicate = build_graph(
             &commits,
             &[],
@@ -2715,7 +2791,7 @@ mod tests {
             &[],
             None,
             None,
-            &[(f1, s), (f1, s)],
+            &[SquashMergeLine::new(f1, s), SquashMergeLine::new(f1, s)],
         );
 
         assert_eq!(
@@ -2723,12 +2799,7 @@ mod tests {
             "repeating one squash relationship must not widen the graph"
         );
         assert_eq!(duplicate.nodes.len(), single.nodes.len());
-        for (row, (actual, expected)) in duplicate
-            .nodes
-            .iter()
-            .zip(&single.nodes)
-            .enumerate()
-        {
+        for (row, (actual, expected)) in duplicate.nodes.iter().zip(&single.nodes).enumerate() {
             assert_eq!(
                 actual.cells, expected.cells,
                 "row {row} must contain exactly the single continuous connector"
@@ -2756,7 +2827,15 @@ mod tests {
         ];
         let unc = Some(Some(1));
         let base = build_graph(&commits, &[], &[], &[], unc, Some(s), &[]);
-        let linked = build_graph(&commits, &[], &[], &[], unc, Some(s), &[(f, s)]);
+        let linked = build_graph(
+            &commits,
+            &[],
+            &[],
+            &[],
+            unc,
+            Some(s),
+            &[SquashMergeLine::new(f, s)],
+        );
 
         let sr = row_of(&linked, s);
         let fr = row_of(&linked, f);
@@ -2844,7 +2923,15 @@ mod tests {
         ];
         let unc = Some(Some(1));
         let base = build_graph(&commits, &[], &[], &[], unc, Some(s), &[]);
-        let linked = build_graph(&commits, &[], &[], &[], unc, Some(s), &[(f, s)]);
+        let linked = build_graph(
+            &commits,
+            &[],
+            &[],
+            &[],
+            unc,
+            Some(s),
+            &[SquashMergeLine::new(f, s)],
+        );
 
         let sr = row_of(&linked, s);
         let fr = row_of(&linked, f);
@@ -2908,7 +2995,15 @@ mod tests {
         ];
         let unc = Some(Some(1));
         let base = build_graph(&commits, &[], &[], &[], unc, Some(s), &[]);
-        let linked = build_graph(&commits, &[], &[], &[], unc, Some(s), &[(f, s)]);
+        let linked = build_graph(
+            &commits,
+            &[],
+            &[],
+            &[],
+            unc,
+            Some(s),
+            &[SquashMergeLine::new(f, s)],
+        );
 
         let sr = row_of(&linked, s);
         let fr = row_of(&linked, f);
@@ -2946,7 +3041,15 @@ mod tests {
         // A link whose target isn't loaded draws nothing (both-endpoints guard).
         let (commits, [_s, f1, _t, _z]) = squash_link_fixture();
         let bogus = oid(200);
-        let missing = build_graph(&commits, &[], &[], &[], None, None, &[(f1, bogus)]);
+        let missing = build_graph(
+            &commits,
+            &[],
+            &[],
+            &[],
+            None,
+            None,
+            &[SquashMergeLine::new(f1, bogus)],
+        );
         assert!(
             !has_squash_grey(&missing),
             "no link is drawn when an endpoint isn't loaded"

--- a/src/git/graph.rs
+++ b/src/git/graph.rs
@@ -2794,6 +2794,60 @@ mod tests {
             &[SquashMergeLine::new(f1, s), SquashMergeLine::new(f1, s)],
         );
 
+        let squash_row = row_of(&duplicate, s);
+        let tip_row = row_of(&duplicate, f1);
+        let connector_col = duplicate.nodes[tip_row].lane * 2;
+
+        assert_eq!(squash_row + 1, tip_row, "fixture endpoints are adjacent");
+        assert_eq!(duplicate.nodes[squash_row].commit.as_ref().unwrap().oid, s);
+        assert_eq!(duplicate.nodes[tip_row].commit.as_ref().unwrap().oid, f1);
+        assert!(matches!(
+            duplicate.nodes[squash_row].cells[connector_col],
+            CellType::BranchLeft(SQUASH_LINK_COLOR_INDEX)
+                | CellType::BranchRight(SQUASH_LINK_COLOR_INDEX)
+        ));
+        assert!(matches!(
+            duplicate.nodes[tip_row].cells[connector_col],
+            CellType::Commit(_)
+        ));
+
+        let grey_cells: Vec<_> = duplicate
+            .nodes
+            .iter()
+            .enumerate()
+            .flat_map(|(row, node)| {
+                node.cells
+                    .iter()
+                    .enumerate()
+                    .filter_map(move |(col, cell)| {
+                        (cell_color(*cell) == Some(SQUASH_LINK_COLOR_INDEX)).then_some((
+                            row,
+                            col,
+                            *cell,
+                            node.cell_oids[col],
+                        ))
+                    })
+            })
+            .collect();
+        assert_eq!(
+            grey_cells,
+            vec![
+                (
+                    squash_row,
+                    connector_col - 1,
+                    CellType::Horizontal(SQUASH_LINK_COLOR_INDEX),
+                    (None, None),
+                ),
+                (
+                    squash_row,
+                    connector_col,
+                    duplicate.nodes[squash_row].cells[connector_col],
+                    (None, None),
+                ),
+            ],
+            "duplicate aliases produce one exact two-cell connector from the squash commit to the adjacent branch-tip dot"
+        );
+
         assert_eq!(
             duplicate.max_lane, single.max_lane,
             "repeating one squash relationship must not widen the graph"

--- a/tests/squash_merge_line_test.rs
+++ b/tests/squash_merge_line_test.rs
@@ -1,0 +1,134 @@
+use chrono::{Local, TimeZone};
+use git2::Oid;
+use keifu::{
+    git::{
+        graph::{build_graph, CellType, GraphLayout, SquashMergeLine},
+        CommitInfo,
+    },
+    graph::colors::SQUASH_LINK_COLOR_INDEX,
+};
+
+fn oid(byte: u8) -> Oid {
+    Oid::from_bytes(&[byte; 20]).unwrap()
+}
+
+fn commit(oid: Oid, parent_oids: Vec<Oid>) -> CommitInfo {
+    CommitInfo {
+        oid,
+        short_id: oid.to_string()[..7].to_string(),
+        author_name: "Test Author".into(),
+        author_email: "test@example.com".into(),
+        timestamp: Local.timestamp_opt(0, 0).single().unwrap(),
+        message: "test".into(),
+        full_message: "test".into(),
+        parent_oids,
+    }
+}
+
+fn row_of(layout: &GraphLayout, oid: Oid) -> usize {
+    layout
+        .nodes
+        .iter()
+        .position(|node| node.commit.as_ref().map(|commit| commit.oid) == Some(oid))
+        .expect("commit is present in the graph layout")
+}
+
+fn cell_color(cell: CellType) -> Option<usize> {
+    match cell {
+        CellType::Empty => None,
+        CellType::Pipe(color)
+        | CellType::Commit(color)
+        | CellType::BranchRight(color)
+        | CellType::BranchLeft(color)
+        | CellType::MergeRight(color)
+        | CellType::MergeLeft(color)
+        | CellType::Horizontal(color)
+        | CellType::TeeRight(color)
+        | CellType::TeeLeft(color)
+        | CellType::TeeUp(color)
+        | CellType::HorizontalPipe(color, _) => Some(color),
+        CellType::TeeDown(_, stem_color) => Some(stem_color),
+    }
+}
+
+#[test]
+fn squash_link_duplicate_relationship_is_idempotent() {
+    let (squash_commit, branch_tip, trunk_parent, shared_base) = (oid(1), oid(4), oid(2), oid(9));
+    let commits = vec![
+        commit(squash_commit, vec![trunk_parent]),
+        commit(branch_tip, vec![shared_base]),
+        commit(trunk_parent, vec![shared_base]),
+        commit(shared_base, vec![]),
+    ];
+    let single_line = SquashMergeLine::new(branch_tip, squash_commit);
+    let single = build_graph(&commits, &[], &[], &[], None, None, &[single_line]);
+    let duplicate = build_graph(
+        &commits,
+        &[],
+        &[],
+        &[],
+        None,
+        None,
+        &[single_line, single_line],
+    );
+
+    let squash_row = row_of(&duplicate, squash_commit);
+    let tip_row = row_of(&duplicate, branch_tip);
+    let connector_col = duplicate.nodes[tip_row].lane * 2;
+    let grey_cells: Vec<_> = duplicate
+        .nodes
+        .iter()
+        .enumerate()
+        .flat_map(|(row, node)| {
+            node.cells
+                .iter()
+                .enumerate()
+                .filter_map(move |(col, cell)| {
+                    (cell_color(*cell) == Some(SQUASH_LINK_COLOR_INDEX)).then_some((
+                        row,
+                        col,
+                        *cell,
+                        node.cell_oids[col],
+                    ))
+                })
+        })
+        .collect();
+
+    assert_eq!(squash_row + 1, tip_row);
+    assert_eq!(
+        duplicate.nodes[squash_row].commit.as_ref().unwrap().oid,
+        squash_commit
+    );
+    assert_eq!(
+        duplicate.nodes[tip_row].commit.as_ref().unwrap().oid,
+        branch_tip
+    );
+    assert_eq!(
+        grey_cells,
+        vec![
+            (
+                squash_row,
+                connector_col - 1,
+                CellType::Horizontal(SQUASH_LINK_COLOR_INDEX),
+                (None, None),
+            ),
+            (
+                squash_row,
+                connector_col,
+                CellType::BranchLeft(SQUASH_LINK_COLOR_INDEX),
+                (None, None),
+            ),
+        ],
+        "duplicate aliases produce one exact connector from squash landing to branch-tip dot",
+    );
+    assert!(matches!(
+        duplicate.nodes[tip_row].cells[connector_col],
+        CellType::Commit(_)
+    ));
+    assert_eq!(duplicate.max_lane, single.max_lane);
+    assert_eq!(duplicate.nodes.len(), single.nodes.len());
+    for (actual, expected) in duplicate.nodes.iter().zip(&single.nodes) {
+        assert_eq!(actual.cells, expected.cells);
+        assert_eq!(actual.cell_oids, expected.cell_oids);
+    }
+}


### PR DESCRIPTION
## Summary

- model squash-merge connectors as endpoint-based `SquashMergeLine` domain values
- deduplicate local/remote ref aliases before layout and defensively at graph injection
- preserve one exact continuous connector with unchanged graph width and document the invariant

## Acceptance Criteria

- [ ] Duplicate local and remote aliases produce exactly one muted-grey connector with the correct branch-tip and squash-landing endpoints.
  Proven by `tests/squash_merge_line_test.rs::squash_link_duplicate_relationship_is_idempotent`, which asserts the exact two-cell connector, endpoint OIDs, connector column, and empty trace-edge metadata.
- [ ] Supplying the same squash relationship twice produces no duplicate arc, detached fragment, or graph widening compared with supplying it once.
  Proven by `tests/squash_merge_line_test.rs::squash_link_duplicate_relationship_is_idempotent`, which asserts the complete cells and edge metadata equal the single-relationship layout and the width is identical.

## Test Plan

- `cargo test --test squash_merge_line_test || exit 1`
- `env -u GIT_AUTHOR_NAME -u GIT_COMMITTER_NAME GIT_CONFIG_GLOBAL=/dev/null cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- Reverting injection-time deduplication makes both regressions fail with six grey cells instead of the exact two-cell connector.

## Adversarial Review

PASS — initial review confirmed endpoint-pair deduplication at alias resolution and graph injection. Scoped repair verification confirmed the exact public-layout assertions, conventional integration-test discovery, absence of synthetic evidence, unchanged width, and the expected red result when deduplication is reverted.

Fixes #156