### PR TITLE
Bound pixel graph startup query timeout

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -134,7 +134,8 @@ Graph.
 
 **How it works:**
 1. `PixelGraphState::new()` (`ui/graph_pixels.rs`) calls
-   `ratatui_image::Picker::from_query_stdio()` once at startup — after raw mode
+   `ratatui_image::Picker::from_query_stdio_with_options()` once at startup with
+   a 250 ms query timeout — after raw mode
    is enabled but before the event loop polls, so crossterm's reader doesn't eat
    the terminal's query reply. It returns `None` (→ Unicode fallback) unless a
    *transparency-preserving* protocol is detected: only **Kitty** and **iTerm2**

--- a/src/debug_server.rs
+++ b/src/debug_server.rs
@@ -275,6 +275,7 @@ fn state_json(app: &App) -> Value {
         "diff_word_wrap": app.diff_word_wrap,
         "commit_detail_word_wrap": app.commit_detail_word_wrap,
         "graph_renderer": app.config.ui.graph_renderer.as_str(),
+        "pixel_graph_active": app.pixel_graph.is_some(),
     })
 }
 

--- a/src/ui/graph_pixels.rs
+++ b/src/ui/graph_pixels.rs
@@ -1549,7 +1549,13 @@ impl PixelGraphState {
     where
         F: FnOnce(QueryStdioOptions) -> Result<Picker, E>,
     {
-        let picker = query(QueryStdioOptions::default()).ok()?;
+        let picker = query(QueryStdioOptions {
+            // Serial consoles and some multiplexers never reply. Bound this
+            // pre-first-frame query while preserving Picker's default probes.
+            timeout: std::time::Duration::from_millis(250),
+            ..QueryStdioOptions::default()
+        })
+        .ok()?;
         if !is_supported_protocol(picker.protocol_type()) {
             return None;
         }

--- a/src/ui/graph_pixels.rs
+++ b/src/ui/graph_pixels.rs
@@ -1545,7 +1545,8 @@ impl PixelGraphState {
 
     /// Build pixel graph state from the startup terminal query, keeping the
     /// terminal I/O boundary injectable for deterministic startup tests.
-    fn from_startup_query<F, E>(query: F) -> Option<Self>
+    #[doc(hidden)]
+    pub fn from_startup_query<F, E>(query: F) -> Option<Self>
     where
         F: FnOnce(QueryStdioOptions) -> Result<Picker, E>,
     {

--- a/src/ui/graph_pixels.rs
+++ b/src/ui/graph_pixels.rs
@@ -2236,6 +2236,36 @@ mod tests {
     }
 
     #[test]
+    fn startup_query_uses_a_short_deadline_and_preserves_picker_fallbacks() {
+        let mut observed_timeout = None;
+        let unsupported = PixelGraphState::from_startup_query(|options| {
+            observed_timeout = Some(options.timeout);
+            Ok::<_, ()>(Picker::halfblocks())
+        });
+
+        assert_eq!(
+            observed_timeout,
+            Some(std::time::Duration::from_millis(250)),
+            "an unresponsive terminal must reach the Unicode fallback promptly"
+        );
+        assert!(
+            unsupported.is_none(),
+            "the existing unsupported-protocol fallback remains Unicode"
+        );
+
+        let detected = PixelGraphState::from_startup_query(|_| {
+            #[allow(deprecated)]
+            let mut picker = Picker::from_fontsize((10, 20));
+            picker.set_protocol_type(ProtocolType::Kitty);
+            Ok::<_, ()>(picker)
+        });
+        assert!(
+            detected.is_some(),
+            "a detected transparency-preserving protocol remains available"
+        );
+    }
+
+    #[test]
     fn prune_lru_evicts_the_stale_half_at_cap() {
         // Under cap: nothing is pruned regardless of age.
         let mut map: HashMap<RowSpec, u64> = HashMap::new();

--- a/src/ui/graph_pixels.rs
+++ b/src/ui/graph_pixels.rs
@@ -1540,17 +1540,7 @@ impl PixelGraphState {
             picker.set_protocol_type(pt);
             return Some(Self::from_picker(picker));
         }
-        Self::from_startup_query(Picker::from_query_stdio_with_options)
-    }
-
-    /// Build pixel graph state from the startup terminal query, keeping the
-    /// terminal I/O boundary injectable for deterministic startup tests.
-    #[doc(hidden)]
-    pub fn from_startup_query<F, E>(query: F) -> Option<Self>
-    where
-        F: FnOnce(QueryStdioOptions) -> Result<Picker, E>,
-    {
-        let picker = query(QueryStdioOptions {
+        let picker = Picker::from_query_stdio_with_options(QueryStdioOptions {
             // Serial consoles and some multiplexers never reply. Bound this
             // pre-first-frame query while preserving Picker's default probes.
             timeout: std::time::Duration::from_millis(250),
@@ -2240,36 +2230,6 @@ mod tests {
         // Halfblocks isn't graphics; Sixel drops alpha → black boxes.
         assert!(!is_supported_protocol(ProtocolType::Halfblocks));
         assert!(!is_supported_protocol(ProtocolType::Sixel));
-    }
-
-    #[test]
-    fn startup_query_uses_a_short_deadline_and_preserves_picker_fallbacks() {
-        let mut observed_timeout = None;
-        let unsupported = PixelGraphState::from_startup_query(|options| {
-            observed_timeout = Some(options.timeout);
-            Ok::<_, ()>(Picker::halfblocks())
-        });
-
-        assert_eq!(
-            observed_timeout,
-            Some(std::time::Duration::from_millis(250)),
-            "an unresponsive terminal must reach the Unicode fallback promptly"
-        );
-        assert!(
-            unsupported.is_none(),
-            "the existing unsupported-protocol fallback remains Unicode"
-        );
-
-        let detected = PixelGraphState::from_startup_query(|_| {
-            #[allow(deprecated)]
-            let mut picker = Picker::from_fontsize((10, 20));
-            picker.set_protocol_type(ProtocolType::Kitty);
-            Ok::<_, ()>(picker)
-        });
-        assert!(
-            detected.is_some(),
-            "a detected transparency-preserving protocol remains available"
-        );
     }
 
     #[test]

--- a/src/ui/graph_pixels.rs
+++ b/src/ui/graph_pixels.rs
@@ -10,6 +10,7 @@ use std::collections::{HashMap, HashSet};
 use image::{DynamicImage, RgbaImage};
 use ratatui::layout::Rect;
 use ratatui::style::Color;
+use ratatui_image::picker::cap_parser::QueryStdioOptions;
 use ratatui_image::picker::{Picker, ProtocolType};
 use ratatui_image::protocol::Protocol;
 use ratatui_image::Resize;
@@ -1539,7 +1540,16 @@ impl PixelGraphState {
             picker.set_protocol_type(pt);
             return Some(Self::from_picker(picker));
         }
-        let picker = Picker::from_query_stdio().ok()?;
+        Self::from_startup_query(Picker::from_query_stdio_with_options)
+    }
+
+    /// Build pixel graph state from the startup terminal query, keeping the
+    /// terminal I/O boundary injectable for deterministic startup tests.
+    fn from_startup_query<F, E>(query: F) -> Option<Self>
+    where
+        F: FnOnce(QueryStdioOptions) -> Result<Picker, E>,
+    {
+        let picker = query(QueryStdioOptions::default()).ok()?;
         if !is_supported_protocol(picker.protocol_type()) {
             return None;
         }

--- a/tests/pixel_graph_startup_timeout_test.rs
+++ b/tests/pixel_graph_startup_timeout_test.rs
@@ -1,34 +1,195 @@
-use std::time::Duration;
+#![cfg(not(windows))]
 
-use keifu::ui::graph_pixels::PixelGraphState;
-use ratatui_image::picker::{Picker, ProtocolType};
+use std::{
+    io::{Read, Write},
+    net::{TcpListener, TcpStream},
+    path::Path,
+    process::Command,
+    thread,
+    time::{Duration, Instant},
+};
+
+use portable_pty::{native_pty_system, Child, CommandBuilder, MasterPty, PtySize};
+use serde_json::Value;
+use tempfile::TempDir;
+
+fn run_git(repo: &Path, args: &[&str]) {
+    let status = Command::new("git").args(args).current_dir(repo).status().unwrap();
+    assert!(status.success(), "git command failed: git {args:?}");
+}
+
+fn fixture_repo() -> TempDir {
+    let repo = tempfile::tempdir().unwrap();
+    run_git(repo.path(), &["init", "-q"]);
+    run_git(repo.path(), &["config", "user.name", "Pixel Test"]);
+    run_git(repo.path(), &["config", "user.email", "pixel@example.test"]);
+    std::fs::write(repo.path().join("README.md"), "fixture\n").unwrap();
+    run_git(repo.path(), &["add", "README.md"]);
+    run_git(repo.path(), &["commit", "-qm", "fixture"]);
+    repo
+}
+
+fn reserve_port() -> u16 {
+    TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+struct RunningApp {
+    child: Box<dyn Child + Send + Sync>,
+    _master: Box<dyn MasterPty + Send>,
+    _config_home: TempDir,
+    reader_thread: thread::JoinHandle<()>,
+}
+
+impl RunningApp {
+    fn stop(mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+        drop(self._master);
+        self.reader_thread.join().unwrap();
+    }
+}
+
+fn start_app(repo: &Path, port: u16, tmux: bool, answer_query: bool) -> RunningApp {
+    let pty = native_pty_system()
+        .openpty(PtySize {
+            rows: 80,
+            cols: 140,
+            pixel_width: 0,
+            pixel_height: 0,
+        })
+        .unwrap();
+    let config_home = tempfile::tempdir().unwrap();
+    let address = format!("127.0.0.1:{port}");
+    let mut command = CommandBuilder::new(env!("CARGO_BIN_EXE_keifu"));
+    command.args(["--debug-listen", &address]);
+    command.cwd(repo);
+    command.env("XDG_CONFIG_HOME", config_home.path());
+    command.env("TERM", if tmux { "tmux-256color" } else { "xterm-256color" });
+    for variable in [
+        "KEIFU_FORCE_PIXEL",
+        "TERM_PROGRAM",
+        "KITTY_WINDOW_ID",
+        "ITERM_SESSION_ID",
+        "WEZTERM_EXECUTABLE",
+    ] {
+        command.env_remove(variable);
+    }
+    let child = pty.slave.spawn_command(command).unwrap();
+    drop(pty.slave);
+
+    let mut reader = pty.master.try_clone_reader().unwrap();
+    let mut writer = pty.master.take_writer().unwrap();
+    let reader_thread = thread::spawn(move || {
+        let mut output = Vec::new();
+        let mut buf = [0; 8192];
+        let mut answered_picker = false;
+        let mut answered_keyboard = false;
+        let mut answered_background = false;
+        while let Ok(read) = reader.read(&mut buf) {
+            if read == 0 {
+                break;
+            }
+            output.extend_from_slice(&buf[..read]);
+            if !answered_keyboard && output.windows(6).any(|part| part == b"\x1b[?u\x1b[") {
+                // Crossterm's keyboard-enhancement probe has its own two
+                // second timeout; report ordinary terminal attributes so the
+                // startup measurement isolates Picker's query.
+                writer.write_all(b"\x1b[?1;2c").unwrap();
+                writer.flush().unwrap();
+                answered_keyboard = true;
+            }
+            if !answered_background && output.windows(5).any(|part| part == b"]11;?") {
+                writer.write_all(b"\x1b]11;rgb:0000/0000/0000\x07\x1b[0n").unwrap();
+                writer.flush().unwrap();
+                answered_background = true;
+            }
+            if answer_query
+                && !answered_picker
+                && output.windows(5).any(|part| part == b"_Gi=3")
+            {
+                // Kitty graphics, a nonzero cell size, then the terminal-status
+                // response which completes the real Picker stdio query.
+                writer
+                    .write_all(b"\x1b_Gi=31;OK\x1b\\\x1b[6;10;20t\x1b[0n")
+                    .unwrap();
+                writer.flush().unwrap();
+                answered_picker = true;
+            }
+        }
+    });
+    RunningApp {
+        child,
+        _master: pty.master,
+        _config_home: config_home,
+        reader_thread,
+    }
+}
+
+fn request(port: u16, body: &str) -> Value {
+    let deadline = Instant::now() + Duration::from_secs(4);
+    let mut stream = loop {
+        match TcpStream::connect(("127.0.0.1", port)) {
+            Ok(stream) => break stream,
+            Err(error) if Instant::now() < deadline => {
+                assert_eq!(error.kind(), std::io::ErrorKind::ConnectionRefused);
+                thread::sleep(Duration::from_millis(10));
+            }
+            Err(error) => panic!("debug server did not start: {error}"),
+        }
+    };
+    stream.write_all(format!("{body}\n").as_bytes()).unwrap();
+    stream.shutdown(std::net::Shutdown::Write).unwrap();
+    let mut response = String::new();
+    stream.read_to_string(&mut response).unwrap();
+    serde_json::from_str(response.trim()).unwrap()
+}
+
+fn startup_state(tmux: bool, answer_query: bool) -> (Duration, Value, RunningApp) {
+    let repo = fixture_repo();
+    let port = reserve_port();
+    let started = Instant::now();
+    let app = start_app(repo.path(), port, tmux, answer_query);
+    // A state request is handled only after the real terminal has rendered its
+    // first frame, so its reply proves startup reached the event loop.
+    let state = request(port, r#"{"cmd":"state"}"#);
+    (started.elapsed(), state, app)
+}
 
 #[test]
-fn startup_query_bounds_unresponsive_terminals_and_keeps_existing_fallbacks() {
-    let mut observed_timeout = None;
-    let fallback = PixelGraphState::from_startup_query(|options| {
-        observed_timeout = Some(options.timeout);
-        Ok::<_, ()>(Picker::halfblocks())
-    });
+fn unanswered_startup_query_reaches_unicode_first_frame_within_the_bound() {
+    let (elapsed, state, app) = startup_state(false, false);
+    app.stop();
 
-    assert_eq!(
-        observed_timeout,
-        Some(Duration::from_millis(250)),
-        "the startup query reaches the Unicode fallback promptly"
-    );
     assert!(
-        fallback.is_none(),
-        "unsupported picker responses retain the existing Unicode fallback"
+        elapsed < Duration::from_millis(1500),
+        "an unanswered Picker query delayed the first frame for {elapsed:?}"
     );
+    assert_eq!(state["ok"], true);
+    assert_eq!(state["pixel_graph_active"], false, "falls back to Unicode");
+}
 
-    let detected = PixelGraphState::from_startup_query(|_| {
-        #[allow(deprecated)]
-        let mut picker = Picker::from_fontsize((10, 20));
-        picker.set_protocol_type(ProtocolType::Kitty);
-        Ok::<_, ()>(picker)
-    });
+#[test]
+fn responsive_startup_query_keeps_the_pixel_graph_active() {
+    let (_elapsed, state, app) = startup_state(false, true);
+    app.stop();
+
+    assert_eq!(state["ok"], true);
+    assert_eq!(state["pixel_graph_active"], true);
+}
+
+#[test]
+fn tmux_without_a_response_keeps_its_unicode_degradation_and_bound() {
+    let (elapsed, state, app) = startup_state(true, false);
+    app.stop();
+
     assert!(
-        detected.is_some(),
-        "supported picker responses still enable the pixel graph"
+        elapsed < Duration::from_millis(1500),
+        "tmux fallback delayed the first frame for {elapsed:?}"
     );
+    assert_eq!(state["ok"], true);
+    assert_eq!(state["pixel_graph_active"], false);
 }

--- a/tests/pixel_graph_startup_timeout_test.rs
+++ b/tests/pixel_graph_startup_timeout_test.rs
@@ -14,7 +14,11 @@ use serde_json::Value;
 use tempfile::TempDir;
 
 fn run_git(repo: &Path, args: &[&str]) {
-    let status = Command::new("git").args(args).current_dir(repo).status().unwrap();
+    let status = Command::new("git")
+        .args(args)
+        .current_dir(repo)
+        .status()
+        .unwrap();
     assert!(status.success(), "git command failed: git {args:?}");
 }
 
@@ -68,7 +72,14 @@ fn start_app(repo: &Path, port: u16, tmux: bool, answer_query: bool) -> RunningA
     command.args(["--debug-listen", &address]);
     command.cwd(repo);
     command.env("XDG_CONFIG_HOME", config_home.path());
-    command.env("TERM", if tmux { "tmux-256color" } else { "xterm-256color" });
+    command.env(
+        "TERM",
+        if tmux {
+            "tmux-256color"
+        } else {
+            "xterm-256color"
+        },
+    );
     for variable in [
         "KEIFU_FORCE_PIXEL",
         "TERM_PROGRAM",
@@ -103,14 +114,13 @@ fn start_app(repo: &Path, port: u16, tmux: bool, answer_query: bool) -> RunningA
                 answered_keyboard = true;
             }
             if !answered_background && output.windows(5).any(|part| part == b"]11;?") {
-                writer.write_all(b"\x1b]11;rgb:0000/0000/0000\x07\x1b[0n").unwrap();
+                writer
+                    .write_all(b"\x1b]11;rgb:0000/0000/0000\x07\x1b[0n")
+                    .unwrap();
                 writer.flush().unwrap();
                 answered_background = true;
             }
-            if answer_query
-                && !answered_picker
-                && output.windows(5).any(|part| part == b"_Gi=3")
-            {
+            if answer_query && !answered_picker && output.windows(5).any(|part| part == b"_Gi=3") {
                 // Kitty graphics, a nonzero cell size, then the terminal-status
                 // response which completes the real Picker stdio query.
                 writer

--- a/tests/pixel_graph_startup_timeout_test.rs
+++ b/tests/pixel_graph_startup_timeout_test.rs
@@ -1,0 +1,34 @@
+use std::time::Duration;
+
+use keifu::ui::graph_pixels::PixelGraphState;
+use ratatui_image::picker::{Picker, ProtocolType};
+
+#[test]
+fn startup_query_bounds_unresponsive_terminals_and_keeps_existing_fallbacks() {
+    let mut observed_timeout = None;
+    let fallback = PixelGraphState::from_startup_query(|options| {
+        observed_timeout = Some(options.timeout);
+        Ok::<_, ()>(Picker::halfblocks())
+    });
+
+    assert_eq!(
+        observed_timeout,
+        Some(Duration::from_millis(250)),
+        "the startup query reaches the Unicode fallback promptly"
+    );
+    assert!(
+        fallback.is_none(),
+        "unsupported picker responses retain the existing Unicode fallback"
+    );
+
+    let detected = PixelGraphState::from_startup_query(|_| {
+        #[allow(deprecated)]
+        let mut picker = Picker::from_fontsize((10, 20));
+        picker.set_protocol_type(ProtocolType::Kitty);
+        Ok::<_, ()>(picker)
+    });
+    assert!(
+        detected.is_some(),
+        "supported picker responses still enable the pixel graph"
+    );
+}


### PR DESCRIPTION
Fixes #18

## Acceptance Criteria
- [ ] Starting the pixel graph on a terminal that does not answer its color query proceeds to the first rendered frame after about 250 ms, using the existing fallback colors.
- [ ] A terminal that answers the startup color query within that bound continues to render with its detected color information.
- [ ] Running under tmux retains its existing color-degradation behavior.

## Test Plan
- `env -u GIT_AUTHOR_NAME -u GIT_AUTHOR_EMAIL -u GIT_COMMITTER_NAME -u GIT_COMMITTER_EMAIL cargo test` (955 active tests passed; the clean environment prevents the runner identity from invalidating the no-user-config regression test).
- `cargo clippy -- -D warnings` passed.
- The integration regression test exercises the startup Picker boundary with a 250 ms timeout, existing Unicode fallback, and supported-protocol availability.

## Adversarial Review
PASS — the timeout is set at the actual Picker startup-query boundary; default tmux detection and responsive protocol handling remain unchanged. The regression test fails when the green timeout change is reverted.