### PR TITLE
Fix New Issue cursor after spaces

### DIFF
--- a/src/ui/issue_compose.rs
+++ b/src/ui/issue_compose.rs
@@ -434,6 +434,21 @@ mod tests {
     }
 
     #[test]
+    fn new_issue_cursor_advances_after_trailing_spaces() {
+        let mut editor = TextEditor::from_text("Issue");
+
+        editor.insert_char(' ');
+        assert_eq!(editor_layout(&editor, 20, 3).cursor, Some((6, 0)));
+
+        editor.insert_char(' ');
+        assert_eq!(editor_layout(&editor, 20, 3).cursor, Some((7, 0)));
+
+        editor.insert_char('t');
+        assert_eq!(editor.text, "Issue  t");
+        assert_eq!(editor_layout(&editor, 20, 3).cursor, Some((8, 0)));
+    }
+
+    #[test]
     fn wrapped_layout_handles_wide_unicode_and_large_pastes() {
         let wide = editor_layout(&TextEditor::from_text("界界界"), 4, 3);
         assert_eq!(

--- a/src/ui/issue_compose.rs
+++ b/src/ui/issue_compose.rs
@@ -149,6 +149,10 @@ pub fn editor_layout(editor: &TextEditor, width: u16, height: u16) -> EditorLayo
     let before_cursor = &editor.text[..editor.cursor];
     let cursor_logical_row = before_cursor.matches('\n').count();
     let logical_start = before_cursor.rfind('\n').map_or(0, |index| index + 1);
+    let logical_end = editor.text[logical_start..]
+        .find('\n')
+        .map_or(editor.text.len(), |index| logical_start + index);
+    let cursor_logical_line = &editor.text[logical_start..logical_end];
     let cursor_byte = editor.cursor - logical_start;
     let (mut cursor_visual_row, mut cursor_visual_col) = lines
         .iter()
@@ -163,8 +167,9 @@ pub fn editor_layout(editor: &TextEditor, width: u16, height: u16) -> EditorLayo
             if cursor_byte < line.end_byte || is_last_for_logical_row {
                 let relative = cursor_byte
                     .saturating_sub(line.start_byte)
-                    .min(line.text.len());
-                let col = UnicodeWidthStr::width(&line.text[..relative]);
+                    .min(line.end_byte - line.start_byte);
+                let end = line.start_byte + relative;
+                let col = UnicodeWidthStr::width(&cursor_logical_line[line.start_byte..end]);
                 Some((index, col))
             } else {
                 None

--- a/src/ui/issue_compose.rs
+++ b/src/ui/issue_compose.rs
@@ -451,6 +451,23 @@ mod tests {
         editor.insert_char('t');
         assert_eq!(editor.text, "Issue  t");
         assert_eq!(editor_layout(&editor, 20, 3).cursor, Some((8, 0)));
+
+        let mut mid_title = TextEditor::from_text("Issuet");
+        mid_title.cursor = "Issue".len();
+        mid_title.insert_char(' ');
+        assert_eq!(editor_layout(&mid_title, 20, 3).cursor, Some((6, 0)));
+        mid_title.insert_char('x');
+        assert_eq!(mid_title.text, "Issue xt");
+        assert_eq!(editor_layout(&mid_title, 20, 3).cursor, Some((7, 0)));
+
+        let mut body = TextEditor::from_text("Issue\nbody");
+        body.cursor = "Issue\nbo".len();
+        body.insert_char(' ');
+        body.insert_char(' ');
+        assert_eq!(editor_layout(&body, 20, 3).cursor, Some((4, 1)));
+        body.insert_char('t');
+        assert_eq!(body.text, "Issue\nbo  tdy");
+        assert_eq!(editor_layout(&body, 20, 3).cursor, Some((5, 1)));
     }
 
     #[test]

--- a/tests/issue_161_cursor_test.rs
+++ b/tests/issue_161_cursor_test.rs
@@ -2,14 +2,14 @@ use keifu::{text_editor::TextEditor, ui::issue_compose::editor_layout};
 
 #[test]
 fn new_issue_cursor_advances_past_inserted_spaces() {
-    let mut title = TextEditor::from_text("Issuet");
-    title.cursor = "Issue".len();
+    let mut title = TextEditor::from_text("Issue");
 
     title.insert_char(' ');
+    assert_eq!(editor_layout(&title, 20, 3).cursor, Some((6, 0)));
     title.insert_char(' ');
     assert_eq!(editor_layout(&title, 20, 3).cursor, Some((7, 0)));
 
     title.insert_char('t');
-    assert_eq!(title.text, "Issue  tt");
+    assert_eq!(title.text, "Issue  t");
     assert_eq!(editor_layout(&title, 20, 3).cursor, Some((8, 0)));
 }

--- a/tests/issue_161_cursor_test.rs
+++ b/tests/issue_161_cursor_test.rs
@@ -1,0 +1,15 @@
+use keifu::{text_editor::TextEditor, ui::issue_compose::editor_layout};
+
+#[test]
+fn new_issue_cursor_advances_past_inserted_spaces() {
+    let mut title = TextEditor::from_text("Issuet");
+    title.cursor = "Issue".len();
+
+    title.insert_char(' ');
+    title.insert_char(' ');
+    assert_eq!(editor_layout(&title, 20, 3).cursor, Some((7, 0)));
+
+    title.insert_char('t');
+    assert_eq!(title.text, "Issue  tt");
+    assert_eq!(editor_layout(&title, 20, 3).cursor, Some((8, 0)));
+}


### PR DESCRIPTION
Fixes #161

## Acceptance Criteria

- [ ] In every editable New Issue modal field, pressing Space inserts exactly one space at the insertion point and the rendered cursor immediately appears one character position after it.
- [ ] Text typed after a space, including consecutive spaces and a space inserted inside existing text, visibly appears after the inserted space.
- [ ] Non-space text entry, cursor movement, and editing in New Issue fields continue to behave as before.

## Verification

- `cargo test --test issue_161_cursor_test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- Live TUI verification in a tmux terminal: New Issue rendered `Issue  t` after two spaces and `t`, with the cursor after the final character.
- `cargo test` has one unrelated host-environment failure: `commit_without_configured_user_maps_to_friendly_error` sees the configured global Git identity in `/home/chong/.gitconfig.local`.

## Adversarial Review

PASS after expanding regression coverage to trailing and consecutive spaces, insertion within existing title text, and body text after a newline. The reviewer confirmed `editor_layout` is the direct producer of the cursor coordinate consumed by `ui::draw`.