### PR TITLE
fix: bound cross-platform CI test jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,7 @@ jobs:
   test:
     name: Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,9 @@ keifu (系譜) is a Rust TUI for git graph visualization — a VSCode-like Git G
 - Track work in GitHub Issues (`gh issue create`). `docs/TODO.md` is a historical log — do not add new entries.
 - Never commit directly to `chong-dev`. Branch → PR (`gh pr create --base chong-dev`, body `Closes #N`) → squash merge. Keep `main` fast-forwarded from `chong-dev`.
 - `cargo test` and `cargo clippy` must pass before a PR.
+- The cross-platform CI test matrix has a 15-minute job timeout so an intermittent
+  runner or test hang settles as a failure instead of pinning a PR indefinitely;
+  `tests/ci_timeout_test.rs` guards that workflow contract.
 - Changes with visible TUI behavior get verified in the real app (debug server: `--debug-listen`, see `docs/debugging.md`), not only through unit tests.
 - Architectural decisions and gotchas go in `docs/architecture.md` when they land.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -945,6 +945,7 @@ dependencies = [
  "ratatui-image",
  "serde",
  "serde_json",
+ "serde_yaml",
  "similar",
  "syntect",
  "tempfile",
@@ -1640,6 +1641,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "serial2"
 version = "0.2.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2081,6 +2095,12 @@ name = "unicode-width"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "url"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,3 +99,4 @@ panic = "abort"
 keifu = { path = ".", features = ["test-support"] }
 filetime = "0.2"
 portable-pty = "0.9"
+serde_yaml = "0.9"

--- a/tests/ci_timeout_test.rs
+++ b/tests/ci_timeout_test.rs
@@ -1,0 +1,45 @@
+use serde_yaml::Value;
+
+fn ci_workflow() -> Value {
+    serde_yaml::from_str(include_str!("../.github/workflows/ci.yaml"))
+        .expect("CI workflow must remain valid YAML")
+}
+
+#[test]
+fn matrix_test_job_settles_within_fifteen_minutes() {
+    let workflow = ci_workflow();
+    let test_job = &workflow["jobs"]["test"];
+
+    assert_eq!(
+        test_job["timeout-minutes"].as_u64(),
+        Some(15),
+        "every OS in the shared test matrix must settle within 15 minutes"
+    );
+}
+
+#[test]
+fn bounded_job_still_runs_the_cross_platform_test_suite() {
+    let workflow = ci_workflow();
+    let test_job = &workflow["jobs"]["test"];
+    let operating_systems = test_job["strategy"]["matrix"]["os"]
+        .as_sequence()
+        .expect("test job must retain an OS matrix")
+        .iter()
+        .filter_map(Value::as_str)
+        .collect::<Vec<_>>();
+    let commands = test_job["steps"]
+        .as_sequence()
+        .expect("test job must retain its steps")
+        .iter()
+        .filter_map(|step| step["run"].as_str())
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        operating_systems,
+        ["ubuntu-latest", "macos-latest", "windows-latest"]
+    );
+    assert!(
+        commands.contains(&"cargo test"),
+        "the bounded job must still run the repository test suite"
+    );
+}


### PR DESCRIPTION
## Summary

Add a 15-minute timeout to the shared cross-platform test job so intermittent Windows runner/test hangs settle as failures instead of pinning PRs indefinitely. The captured hangs occurred in four unrelated tests, so this applies the bound at the common CI seam rather than adding an unsupported keyboard-specific workaround.

## Acceptance Criteria

- [ ] Every CI matrix test job on Ubuntu, macOS, and Windows reaches a terminal result within 15 minutes, so a hung test cannot remain pending indefinitely.
- [ ] Normal test execution remains unchanged: the existing repository test suite still runs on every operating system in the matrix and successful runs remain green.

## Test Plan

- `cargo test --test ci_timeout_test` — PASS (2 tests); reverting the workflow timeout makes the timeout assertion fail.
- `cargo clippy -- -D warnings` — PASS.
- `cargo fmt --check` — PASS.
- Full `cargo test` exercised the suite; the changed contract and previously observed hanging staging/rebase/archive/startup tests pass locally. One unrelated pre-existing identity test fails under local Git 2.51 because empty repository identity values fall back to the OS identity; the same test is unchanged in this diff.

## Adversarial Review

PASS: correct workflow seam, non-tautological revert-sensitive regression, preserved OS matrix and `cargo test` step, and valid GitHub Actions job placement.

Fixes #185